### PR TITLE
Align parser and ast with new grammar

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -255,7 +255,7 @@ normMain NormalizeOptions { normInput = inputPath
      writeOutput True outputPath out
 
 optimMain :: OptimizeOptions -> IO ()
-optimMain  = undefined --TODO: fix when adding PE support for processes
+optimMain  = undefined --TODO: fix when adding PE support for procedures
 -- optimMain OptimizeOptions { optimInput = inputPath
 --                           , optimOutput = outputPath
 --                           , optimBidirectional = useBidir
@@ -275,7 +275,7 @@ optimMain  = undefined --TODO: fix when adding PE support for processes
 --     isAssertion _ = False
 
 intMain :: InterpretOptions -> IO ()
-intMain = undefined --TODO: fix when adding interpreter support for processes
+intMain = undefined --TODO: fix when adding interpreter support for procedures
 -- intMain InterpretOptions { intFile = filePath
 --                          , intInputFile = inputPath
 --                          , intVerbose = v} =
@@ -294,7 +294,7 @@ intMain = undefined --TODO: fix when adding interpreter support for processes
 --      putStrLn $ prettyStats stats
 
 specMain :: SpecOptions -> IO ()
-specMain  = undefined --TODO: fix when adding PE support for processes
+specMain  = undefined --TODO: fix when adding PE support for procedures
 -- specMain specOpts@SpecOptions { specInpFile = inputPath
 --                               , specOutFile = outputPath
 --                               , uniformBTA  = uniform
@@ -334,7 +334,7 @@ btaPW p d =
   in makeCongruentPW p initd
 
 specMain2 :: SpecOptions -> VariableDecl -> Program' (Explicated Label) -> SpecStore -> IO String
-specMain2 = undefined --TODO: fix when adding PE support for processes
+specMain2 = undefined --TODO: fix when adding PE support for procedures
 -- specMain2 specOpts decl prog2 store =
 --   let v = specVerbose specOpts
 --   in
@@ -358,7 +358,7 @@ specMain2 = undefined --TODO: fix when adding PE support for processes
 
 specPostProcess :: Bool -> VariableDecl -> Program (Explicated Label) (Maybe SpecStore)
                 -> IO (Program Label (), [(Name, SpecValue)])
-specPostProcess = undefined --TODO: fix when adding PE support for processes
+specPostProcess = undefined --TODO: fix when adding PE support for procedures
 -- specPostProcess v origdecl (decl, prog) =
   -- do let showLength p = trace v $ "Nr. of blocks: " ++ show (length p)
   --    showLength prog
@@ -402,7 +402,7 @@ printStaticOutput decl tpls =
     showSpecVal Dynamic = undefined
 
 benchMain :: BenchOptions -> IO ()
-benchMain = undefined --TODO: fix when adding PE support for processes
+benchMain = undefined --TODO: fix when adding PE support for procedures
 -- benchMain BenchOptions { benchFile     = inputPath
 --                        , benchSpecFile = specPath
 --                        , dynamicVars   = dyn

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -255,74 +255,77 @@ normMain NormalizeOptions { normInput = inputPath
      writeOutput True outputPath out
 
 optimMain :: OptimizeOptions -> IO ()
-optimMain OptimizeOptions { optimInput = inputPath
-                          , optimOutput = outputPath
-                          , optimBidirectional = useBidir
-                          , optimVerbose = v} =
-  do prog <- parseFile "program" v parseProg inputPath
-     let mode = if useBidir then " (BIDIRECTIONAL)" else ""
-     trace v $ "- Removing assertions" ++ mode
-     let removeAsserts = if useBidir then removeAssertionsBi else removeAssertionsUni
-     let optimProg = removeAsserts prog
-     let out = prettyProg id optimProg
-     trace v $ "Assertions removed: " ++ show (assCount prog - assCount optimProg)
-     trace v $ "Assertions remaining: " ++ show (assCount optimProg)
-     writeOutput v outputPath out
-  where
-    assCount = sum . map (length . filter isAssertion . body) . snd
-    isAssertion (Assert _) = True
-    isAssertion _ = False
+optimMain  = undefined --TODO: fix when adding PE support for processes
+-- optimMain OptimizeOptions { optimInput = inputPath
+--                           , optimOutput = outputPath
+--                           , optimBidirectional = useBidir
+--                           , optimVerbose = v} =
+--   do prog <- parseFile "program" v parseProg inputPath
+--      let mode = if useBidir then " (BIDIRECTIONAL)" else ""
+--      trace v $ "- Removing assertions" ++ mode
+--      let removeAsserts = if useBidir then removeAssertionsBi else removeAssertionsUni
+--      let optimProg = removeAsserts prog
+--      let out = prettyProg id optimProg
+--      trace v $ "Assertions removed: " ++ show (assCount prog - assCount optimProg)
+--      trace v $ "Assertions remaining: " ++ show (assCount optimProg)
+--      writeOutput v outputPath out
+--   where
+--     assCount = sum . map (length . filter isAssertion . body) . snd
+--     isAssertion (Assert _) = True
+--     isAssertion _ = False
 
 intMain :: InterpretOptions -> IO ()
-intMain InterpretOptions { intFile = filePath
-                         , intInputFile = inputPath
-                         , intVerbose = v} =
-  do prog <- parseFile "program" v parseProg filePath
-     _ <- fromEM "performing wellformedness check of input prog"
-              $ wellformedProg prog
-     initStore <- parseFile "division and specilization data" v parseSpec inputPath
-     (out, _) <- fromLEM "execution" $ runProgram prog initStore
-     let (outStore, stats) = out
-     trace v "Output store: "
-     let outvals = filter (\(n, _) -> n `elem` output (fst prog))
-                    $ toList outStore
-     let outstr = map (\(n, val) -> n ++ ": " ++ prettyVal val) outvals
-     putStrLn (unlines outstr)
-     trace v "Execution statistics: "
-     putStrLn $ prettyStats stats
+intMain = undefined --TODO: fix when adding interpreter support for processes
+-- intMain InterpretOptions { intFile = filePath
+--                          , intInputFile = inputPath
+--                          , intVerbose = v} =
+--   do prog <- parseFile "program" v parseProg filePath
+--      _ <- fromEM "performing wellformedness check of input prog"
+--               $ wellformedProg prog
+--      initStore <- parseFile "division and specilization data" v parseSpec inputPath
+--      (out, _) <- fromLEM "execution" $ runProgram prog initStore
+--      let (outStore, stats) = out
+--      trace v "Output store: "
+--      let outvals = filter (\(n, _) -> n `elem` output (fst prog))
+--                     $ toList outStore
+--      let outstr = map (\(n, val) -> n ++ ": " ++ prettyVal val) outvals
+--      putStrLn (unlines outstr)
+--      trace v "Execution statistics: "
+--      putStrLn $ prettyStats stats
 
 specMain :: SpecOptions -> IO ()
-specMain specOpts@SpecOptions { specInpFile = inputPath
-                              , specOutFile = outputPath
-                              , uniformBTA  = uniform
-                              , specFile    = specPath
-                              , specVerbose = v
-                              , specIgnore  = ignores} =
-  do prog <- parseFile "program" v parseProg inputPath
-     let decl = fst prog
-     _ <- fromEM "performing wellformedness check of input prog"
-              $ wellformedProg prog
-     initStore' <- parseFile "division and specilization data"
-                    v parseSpec specPath
-     let initStore = initStore' `withouts` ignores
-     trace v "- Normalizing input program."
-     let nprog = normalize "init" "stop" prog (\l i -> l ++ "_" ++ show i)
-     trace v "- Creating initial binding."
-     d <- fromEM "binding" $ makeDiv initStore decl
-     trace v $ "- Performing BTA " ++ if uniform then "(uniform)" else "(pointwise)"
-     let btaFunc = if uniform then btaUniform else btaPW
-     let congruentDiv = btaFunc nprog d
-     let store = makeSpecStore decl (startingDiv nprog congruentDiv) initStore
-     trace v "- Annotating program"
-     let prog2 = annotateProg congruentDiv nprog
-     _ <- fromEM "wellformedness of 2 level lang. This should never happen. Please report."
-                 (wellformedProg' congruentDiv prog2)
-     let explicated = explicate congruentDiv prog2 (\l i -> l ++ "_" ++ show i)
-     out <- if skipSpecPhase specOpts
-              then do trace v "- Skip specialization";
-                      return $ prettyProg' (serializeExpl id) explicated
-              else specMain2 specOpts decl explicated store
-     writeOutput v outputPath out
+specMain  = undefined --TODO: fix when adding PE support for processes
+-- specMain specOpts@SpecOptions { specInpFile = inputPath
+--                               , specOutFile = outputPath
+--                               , uniformBTA  = uniform
+--                               , specFile    = specPath
+--                               , specVerbose = v
+--                               , specIgnore  = ignores} =
+--   do prog <- parseFile "program" v parseProg inputPath
+--      let decl = fst prog
+--      _ <- fromEM "performing wellformedness check of input prog"
+--               $ wellformedProg prog
+--      initStore' <- parseFile "division and specilization data"
+--                     v parseSpec specPath
+--      let initStore = initStore' `withouts` ignores
+--      trace v "- Normalizing input program."
+--      let nprog = normalize "init" "stop" prog (\l i -> l ++ "_" ++ show i)
+--      trace v "- Creating initial binding."
+--      d <- fromEM "binding" $ makeDiv initStore decl
+--      trace v $ "- Performing BTA " ++ if uniform then "(uniform)" else "(pointwise)"
+--      let btaFunc = if uniform then btaUniform else btaPW
+--      let congruentDiv = btaFunc nprog d
+--      let store = makeSpecStore decl (startingDiv nprog congruentDiv) initStore
+--      trace v "- Annotating program"
+--      let prog2 = annotateProg congruentDiv nprog
+--      _ <- fromEM "wellformedness of 2 level lang. This should never happen. Please report."
+--                  (wellformedProg' congruentDiv prog2)
+--      let explicated = explicate congruentDiv prog2 (\l i -> l ++ "_" ++ show i)
+--      out <- if skipSpecPhase specOpts
+--               then do trace v "- Skip specialization";
+--                       return $ prettyProg' (serializeExpl id) explicated
+--               else specMain2 specOpts decl explicated store
+--      writeOutput v outputPath out
 
 btaUniform, btaPW :: NormProgram Label -> Division -> PWDivision Label
 btaUniform = congruentUniformDiv
@@ -331,59 +334,61 @@ btaPW p d =
   in makeCongruentPW p initd
 
 specMain2 :: SpecOptions -> VariableDecl -> Program' (Explicated Label) -> SpecStore -> IO String
-specMain2 specOpts decl prog2 store =
-  let v = specVerbose specOpts
-  in
-  do trace v "- Specializing"
-     (res, l) <- fromLEM "specializing" $ specialize decl prog2 store (Regular "entry")
-     trace (specTrace specOpts) $ "Trace: (label: State)\n" ++ unlines l
-     let (resdecl, resbody) = res
-     if skipPost specOpts
-     then do
-        trace v "- Skip post processing"
-        let clean = mapCombine (serializeAnn (serializeExpl id)) resbody
-        return $ prettyProg id (resdecl, clean)
-     else do
-        trace v "- POST PROCESSING"
-        (prog', staticVals) <- specPostProcess v decl res
-        let prog = if specAssertRem specOpts
-                   then removeAllAssertions prog'
-                   else prog'
-        printStaticOutput decl staticVals
-        return $ prettyProg id prog
+specMain2 = undefined --TODO: fix when adding PE support for processes
+-- specMain2 specOpts decl prog2 store =
+--   let v = specVerbose specOpts
+--   in
+--   do trace v "- Specializing"
+--      (res, l) <- fromLEM "specializing" $ specialize decl prog2 store (Regular "entry")
+--      trace (specTrace specOpts) $ "Trace: (label: State)\n" ++ unlines l
+--      let (resdecl, resbody) = res
+--      if skipPost specOpts
+--      then do
+--         trace v "- Skip post processing"
+--         let clean = mapCombine (serializeAnn (serializeExpl id)) resbody
+--         return $ prettyProg id (resdecl, clean)
+--      else do
+--         trace v "- POST PROCESSING"
+--         (prog', staticVals) <- specPostProcess v decl res
+--         let prog = if specAssertRem specOpts
+--                    then removeAllAssertions prog'
+--                    else prog'
+--         printStaticOutput decl staticVals
+--         return $ prettyProg id prog
 
 specPostProcess :: Bool -> VariableDecl -> Program (Explicated Label) (Maybe SpecStore)
                 -> IO (Program Label (), [(Name, SpecValue)])
-specPostProcess v origdecl (decl, prog) =
-  do let showLength p = trace v $ "Nr. of blocks: " ++ show (length p)
-     showLength prog
-     trace v "- Folding constants"
-     (folded, out) <- fromLEM "Folding" $ constFold prog
-     trace v $ "Expressions reduced: " ++ show (length out)
-     trace v "- Merging explicitors"
-     let cleanStores = mapProgStore (fromMaybe emptyMap) folded
-     let merged' = mergeExplicators (\l i1 i2 -> l ++ "_e" ++ show i1 ++ "_" ++ show i2) cleanStores
-     let merged = mapLabel (serializeExpl id) merged'
-     showLength merged
-     trace v "- Merging exits"
-     let ((decl', singleExit), staticVals) =
-            mergeExits origdecl (\l i1 i2 -> l ++ "_x" ++ show i1 ++ "_" ++ show i2) (decl, merged)
-     showLength singleExit
-     trace v "- Removing dead blocks"
-     let liveProg = removeDeadBlocks singleExit
-     showLength liveProg
-     trace v "- Adding assertions / Making blocks wellformed"
-     let withAssertions = changeConditionals liveProg
-     fromEM "Wellformedness check 1" $ wellformedProg (decl', withAssertions)
-     trace v "- Cleaning names"
-     let numeratedStore = enumerateAnn withAssertions
-     let clean = mapCombine (\l s -> l ++ "_" ++ show s) numeratedStore
-     fromEM "Wellformedness check 2" $ wellformedProg (decl', clean)
-     trace v "- Compressing paths"
-     let compressed = compressPaths clean
-     fromEM "Wellformedness check 3" $ wellformedProg (decl', compressed)
-     showLength compressed
-     return ((decl', compressed), staticVals)
+specPostProcess = undefined --TODO: fix when adding PE support for processes
+-- specPostProcess v origdecl (decl, prog) =
+  -- do let showLength p = trace v $ "Nr. of blocks: " ++ show (length p)
+  --    showLength prog
+  --    trace v "- Folding constants"
+  --    (folded, out) <- fromLEM "Folding" $ constFold prog
+  --    trace v $ "Expressions reduced: " ++ show (length out)
+  --    trace v "- Merging explicitors"
+  --    let cleanStores = mapProgStore (fromMaybe emptyMap) folded
+  --    let merged' = mergeExplicators (\l i1 i2 -> l ++ "_e" ++ show i1 ++ "_" ++ show i2) cleanStores
+  --    let merged = mapLabel (serializeExpl id) merged'
+  --    showLength merged
+  --    trace v "- Merging exits"
+  --    let ((decl', singleExit), staticVals) =
+  --           mergeExits origdecl (\l i1 i2 -> l ++ "_x" ++ show i1 ++ "_" ++ show i2) (decl, merged)
+  --    showLength singleExit
+  --    trace v "- Removing dead blocks"
+  --    let liveProg = removeDeadBlocks singleExit
+  --    showLength liveProg
+  --    trace v "- Adding assertions / Making blocks wellformed"
+  --    let withAssertions = changeConditionals liveProg
+  --    fromEM "Wellformedness check 1" $ wellformedProg (decl', withAssertions)
+  --    trace v "- Cleaning names"
+  --    let numeratedStore = enumerateAnn withAssertions
+  --    let clean = mapCombine (\l s -> l ++ "_" ++ show s) numeratedStore
+  --    fromEM "Wellformedness check 2" $ wellformedProg (decl', clean)
+  --    trace v "- Compressing paths"
+  --    let compressed = compressPaths clean
+  --    fromEM "Wellformedness check 3" $ wellformedProg (decl', compressed)
+  --    showLength compressed
+  --    return ((decl', compressed), staticVals)
 
 printStaticOutput :: VariableDecl -> [(Name, SpecValue)] -> IO ()
 printStaticOutput decl tpls =
@@ -397,91 +402,92 @@ printStaticOutput decl tpls =
     showSpecVal Dynamic = undefined
 
 benchMain :: BenchOptions -> IO ()
-benchMain BenchOptions { benchFile     = inputPath
-                       , benchSpecFile = specPath
-                       , dynamicVars   = dyn
-                       , benchVerbose  = v } =
-  do prog <- parseFile "program" False parseProg inputPath
-     fromEM "wellformedness of input prog" $ wellformedProg prog
-     trace v "Initial interpretation"
-     completeStore <- parseFile "input" False parseSpec specPath
-     ((outInt, statsInt), _) <- fromLEM "execution" $ runProgram prog completeStore
-     let decl = fst prog
-     let initStore = completeStore `withouts` dyn
-     d <- fromEM "binding" $ makeDiv initStore decl
-     let nprog = normalize' prog
-     let pipeline' = pipeline nprog d decl completeStore initStore outInt
-     (resUni, statsUni) <- pipeline' "UNI" btaUniform
-     (resPW, statsPW) <- pipeline' "PW" btaPW
-     putStrLn $ "-- Source program\n" ++ prettyStats statsInt
-     putStrLn $ prettySize (prog, prog)
-     prettySpeed' "Uniform PE" statsInt statsUni
-     putStrLn $ prettySize resUni
-     prettySpeed' "Pointwise PE" statsInt statsPW
-     putStrLn $ prettySize resPW
-  where
+benchMain = undefined --TODO: fix when adding PE support for processes
+-- benchMain BenchOptions { benchFile     = inputPath
+--                        , benchSpecFile = specPath
+--                        , dynamicVars   = dyn
+--                        , benchVerbose  = v } =
+--   do prog <- parseFile "program" False parseProg inputPath
+--      fromEM "wellformedness of input prog" $ wellformedProg prog
+--      trace v "Initial interpretation"
+--      completeStore <- parseFile "input" False parseSpec specPath
+--      ((outInt, statsInt), _) <- fromLEM "execution" $ runProgram prog completeStore
+--      let decl = fst prog
+--      let initStore = completeStore `withouts` dyn
+--      d <- fromEM "binding" $ makeDiv initStore decl
+--      let nprog = normalize' prog
+--      let pipeline' = pipeline nprog d decl completeStore initStore outInt
+--      (resUni, statsUni) <- pipeline' "UNI" btaUniform
+--      (resPW, statsPW) <- pipeline' "PW" btaPW
+--      putStrLn $ "-- Source program\n" ++ prettyStats statsInt
+--      putStrLn $ prettySize (prog, prog)
+--      prettySpeed' "Uniform PE" statsInt statsUni
+--      putStrLn $ prettySize resUni
+--      prettySpeed' "Pointwise PE" statsInt statsPW
+--      putStrLn $ prettySize resPW
+--   where
 
-    pipeline nprog d decl runstore initSpec origOut mode bta =
-      do (prog2, startDiv) <- preprocess mode bta nprog d
-         let specStore = makeSpecStore decl startDiv initSpec
-         res <- specialize' mode decl prog2 specStore
-         (prog, outStatic) <- postprocess mode decl res
-         (outRes, stats) <- run mode prog runstore
-         let progOptim = removeAllAssertions prog
-         (_, statsOptim) <- run mode progOptim runstore
-         let combinedOut = combine (toStore $ fromList outStatic) outRes
-         verifyOutput mode origOut combinedOut
-         fromEM ("wellformedness of residual prog " ++ mode) $
-            wellformedProg prog
-         return ((prog, progOptim), (stats, statsOptim))
+--     pipeline nprog d decl runstore initSpec origOut mode bta =
+--       do (prog2, startDiv) <- preprocess mode bta nprog d
+--          let specStore = makeSpecStore decl startDiv initSpec
+--          res <- specialize' mode decl prog2 specStore
+--          (prog, outStatic) <- postprocess mode decl res
+--          (outRes, stats) <- run mode prog runstore
+--          let progOptim = removeAllAssertions prog
+--          (_, statsOptim) <- run mode progOptim runstore
+--          let combinedOut = combine (toStore $ fromList outStatic) outRes
+--          verifyOutput mode origOut combinedOut
+--          fromEM ("wellformedness of residual prog " ++ mode) $
+--             wellformedProg prog
+--          return ((prog, progOptim), (stats, statsOptim))
 
-    preprocess mode bta nprog d =
-      do trace v $ "Preprocessing " ++ mode
-         let cdiv = bta nprog d
-         let p2 = annotateProg cdiv nprog
-         fromEM "wellformedness of RL2 prog" (wellformedProg' cdiv p2)
-         let expl = explicate cdiv p2 (\l i -> l ++ "_" ++ show i)
-         return (expl, startingDiv nprog cdiv)
+--     preprocess mode bta nprog d =
+--       do trace v $ "Preprocessing " ++ mode
+--          let cdiv = bta nprog d
+--          let p2 = annotateProg cdiv nprog
+--          fromEM "wellformedness of RL2 prog" (wellformedProg' cdiv p2)
+--          let expl = explicate cdiv p2 (\l i -> l ++ "_" ++ show i)
+--          return (expl, startingDiv nprog cdiv)
 
-    run mode p s =
-      do trace v $ "Interpreting " ++ mode
-         (res, _) <- fromLEM "execution" $ runProgram' p s
-         return res
+--     run mode p s =
+--       do trace v $ "Interpreting " ++ mode
+--          (res, _) <- fromLEM "execution" $ runProgram' p s
+--          return res
 
-    normalize' p = normalize "init" "stop" p (\l i -> l ++ "_" ++ show i)
+--     normalize' p = normalize "init" "stop" p (\l i -> l ++ "_" ++ show i)
 
-    specialize' mode d p s =
-      do trace v $ "Specializing " ++ mode
-         (prog, _) <- fromLEM "specializing" $ specialize d p s (Regular "entry")
-         return prog
+--     specialize' mode d p s =
+--       do trace v $ "Specializing " ++ mode
+--          (prog, _) <- fromLEM "specializing" $ specialize d p s (Regular "entry")
+--          return prog
 
-    postprocess mode origdecl prog =
-      do trace v $ "Postprocessing " ++ mode
-         specPostProcess False origdecl prog
+--     postprocess mode origdecl prog =
+--       do trace v $ "Postprocessing " ++ mode
+--          specPostProcess False origdecl prog
 
-    verifyOutput mode regularOut specOut =
-      do trace v $ "Checking output " ++ mode
-         unless (all (\(n, val) -> val == get n specOut) (toList regularOut))
-            $ die "The regular and specialized output do not match"
+--     verifyOutput mode regularOut specOut =
+--       do trace v $ "Checking output " ++ mode
+--          unless (all (\(n, val) -> val == get n specOut) (toList regularOut))
+--             $ die "The regular and specialized output do not match"
 
-    prettySpeed' mode origStats (newStats, newStatsO) =
-      let origSpeed = totalSteps origStats
-          newSpeed = totalSteps newStats
-          newSpeedO = totalSteps newStatsO
-          speedup, speedupO :: Float
-          speedup = fromIntegral origSpeed / fromIntegral newSpeed
-          speedupO = fromIntegral origSpeed / fromIntegral newSpeedO
-      in do putStrLn $ "-- " ++ mode
-            putStrLn $ prettyStats2 newStats newStatsO
-            putStrLn $ "Speedup: " ++ take 5 (show speedup) ++ "x" ++ brace (take 5 (show speedupO) ++ "x")
+--     prettySpeed' mode origStats (newStats, newStatsO) =
+--       let origSpeed = totalSteps origStats
+--           newSpeed = totalSteps newStats
+--           newSpeedO = totalSteps newStatsO
+--           speedup, speedupO :: Float
+--           speedup = fromIntegral origSpeed / fromIntegral newSpeed
+--           speedupO = fromIntegral origSpeed / fromIntegral newSpeedO
+--       in do putStrLn $ "-- " ++ mode
+--             putStrLn $ prettyStats2 newStats newStatsO
+--             putStrLn $ "Speedup: " ++ take 5 (show speedup) ++ "x" ++ brace (take 5 (show speedupO) ++ "x")
 
-    brace s = " (" ++ s ++ ")"
-    blocks = show . length
-    lineCount p = show $ sum (map (length . body) p) + 2 * length p
-    prettySize ((_, prog), (_, progOptim)) = "Total Blocks: " ++ blocks prog ++ brace (blocks progOptim)
-                        ++ ", Total Lines: " ++ lineCount prog ++ brace (lineCount progOptim)
-                        ++ ", Asserts removed: " ++ show (asserts prog - asserts progOptim ) ++ "/" ++ show (asserts prog)
-    asserts = sum . map (length . filter (\s -> case s of Assert _ -> True; _ -> False) . body)
+--     brace s = " (" ++ s ++ ")"
+--     blocks = show . length
+--     lineCount p = show $ sum (map (length . body) p) + 2 * length p
+--     prettySize ((_, prog), (_, progOptim)) = "Total Blocks: " ++ blocks prog ++ brace (blocks progOptim)
+--                         ++ ", Total Lines: " ++ lineCount prog ++ brace (lineCount progOptim)
+--                         ++ ", Asserts removed: " ++ show (asserts prog - asserts progOptim ) ++ "/" ++ show (asserts prog)
+--     asserts = sum . map (length . filter (\s -> case s of Assert _ -> True; _ -> False) . body)
 
 makeSpecStore :: VariableDecl -> Division -> Store -> SpecStore
 makeSpecStore decl d s =

--- a/src/Assertions/Impl/Analysis.hs
+++ b/src/Assertions/Impl/Analysis.hs
@@ -18,7 +18,7 @@ type AStore = Map Name AValue
 type State a b = Map (a,b) (Maybe AStore)
 
 inferProg :: (Ord a, Ord b) => Program a b -> State a b -> State a b
-inferProg = undefined --TODO: fix when adding PE support for processes
+inferProg = undefined --TODO: fix when adding PE support for procedures
 -- inferProg (decl, prog) preState =
 --   let postState = fromList $ map (\b -> (name b, Nothing)) prog
 --       entryLabel = getEntryName prog
@@ -34,7 +34,7 @@ inferProg = undefined --TODO: fix when adding PE support for processes
 --       in fixPoint newState ls'
 
 inferProgWithoutAsserts :: (Ord a, Ord b) => Program a b -> State a b -> State a b
-inferProgWithoutAsserts = undefined --TODO: fix when adding PE support for processes
+inferProgWithoutAsserts = undefined --TODO: fix when adding PE support for procedures
 -- inferProgWithoutAsserts (decl, prog) = inferProg (decl, prog')
 --   where
 --     notAssert (Assert _) = False
@@ -62,7 +62,7 @@ inferBlock preState postState prog
 inferFrom :: (Ord a, Ord b) => State a b -> Program a b
                             -> (a, b) -> ComeFrom a b
                             -> Maybe AStore
-inferFrom = undefined --TODO: fix when adding PE support for processes
+inferFrom = undefined --TODO: fix when adding PE support for procedures
 -- inferFrom _ (decl, _) _ (Entry _) = inferDecl decl
 
 -- inferFrom state (_, prog) l (From l1) =

--- a/src/Assertions/Impl/Analysis.hs
+++ b/src/Assertions/Impl/Analysis.hs
@@ -18,27 +18,29 @@ type AStore = Map Name AValue
 type State a b = Map (a,b) (Maybe AStore)
 
 inferProg :: (Ord a, Ord b) => Program a b -> State a b -> State a b
-inferProg (decl, prog) preState =
-  let postState = fromList $ map (\b -> (name b, Nothing)) prog
-      entryLabel = getEntryName prog
-      finalState = fixPoint postState [entryLabel]
-  in finalState
-  where
-    fixPoint postState [] = postState
-    fixPoint postState (l:ls) =
-      let b = getBlockUnsafe prog l
-          (newState, pending) =
-            inferBlock preState postState (decl, prog) b
-          ls' = List.union ls pending
-      in fixPoint newState ls'
+inferProg = undefined --TODO: fix when adding PE support for processes
+-- inferProg (decl, prog) preState =
+--   let postState = fromList $ map (\b -> (name b, Nothing)) prog
+--       entryLabel = getEntryName prog
+--       finalState = fixPoint postState [entryLabel]
+--   in finalState
+--   where
+--     fixPoint postState [] = postState
+--     fixPoint postState (l:ls) =
+--       let b = getBlockUnsafe prog l
+--           (newState, pending) =
+--             inferBlock preState postState (decl, prog) b
+--           ls' = List.union ls pending
+--       in fixPoint newState ls'
 
 inferProgWithoutAsserts :: (Ord a, Ord b) => Program a b -> State a b -> State a b
-inferProgWithoutAsserts (decl, prog) = inferProg (decl, prog')
-  where
-    notAssert (Assert _) = False
-    notAssert _          = True
-    removeAssertion b = b{body = filter notAssert $ body b}
-    prog' = map removeAssertion prog
+inferProgWithoutAsserts = undefined --TODO: fix when adding PE support for processes
+-- inferProgWithoutAsserts (decl, prog) = inferProg (decl, prog')
+--   where
+--     notAssert (Assert _) = False
+--     notAssert _          = True
+--     removeAssertion b = b{body = filter notAssert $ body b}
+--     prog' = map removeAssertion prog
 
 -- Update state and return new pending points
 inferBlock :: (Ord a, Ord b) => State a b -> State a b
@@ -60,28 +62,29 @@ inferBlock preState postState prog
 inferFrom :: (Ord a, Ord b) => State a b -> Program a b
                             -> (a, b) -> ComeFrom a b
                             -> Maybe AStore
-inferFrom _ (decl, _) _ (Entry _) = inferDecl decl
+inferFrom = undefined --TODO: fix when adding PE support for processes
+-- inferFrom _ (decl, _) _ (Entry _) = inferDecl decl
 
-inferFrom state (_, prog) l (From l1) =
-  let origS = get l1 state
-      j = jump $ getBlockUnsafe prog l1
-  in inferJump origS l j
-inferFrom state (_, prog) l (Fi e l1 l2) =
-  let inferJump' orig e' =
-          let origS = get orig state
-              j = jump $ getBlockUnsafe prog orig
-              origS' = inferJump origS l j
-          in inferAssertion' origS' e'
-      inferred1 = inferJump' l1 e
-      inferred2 = inferJump' l2 (UOp Not e)
-  in inferred1 `lubStore` inferred2
+-- inferFrom state (_, prog) l (From l1) =
+--   let origS = get l1 state
+--       j = jump $ getBlockUnsafe prog l1
+--   in inferJump origS l j
+-- inferFrom state (_, prog) l (Fi e l1 l2) =
+--   let inferJump' orig e' =
+--           let origS = get orig state
+--               j = jump $ getBlockUnsafe prog orig
+--               origS' = inferJump origS l j
+--           in inferAssertion' origS' e'
+--       inferred1 = inferJump' l1 e
+--       inferred2 = inferJump' l2 (UOp Not e)
+--   in inferred1 `lubStore` inferred2
 
 inferJump :: (Ord a, Ord b) => Maybe AStore -> (a,b) -> Jump a b -> Maybe AStore
 inferJump store _ (Goto _) = store
 inferJump store dest (If e l1 _)
   | l1 == dest = inferAssertion' store e
   | otherwise  = inferAssertion' store (UOp Not e)
-inferJump _ _ (Exit _) = undefined
+inferJump _ _ (Exit _ _) = undefined --TODO: consider exit pattern
 
 -- glb of store lattice
 glbStore :: Maybe AStore -> Maybe AStore -> Maybe AStore

--- a/src/Assertions/Impl/Removal.hs
+++ b/src/Assertions/Impl/Removal.hs
@@ -46,23 +46,25 @@ removeAssertionsBi prog =
 
 postToPre :: (Ord a, Ord b) => Program a b -> State a b
                             -> State a b
-postToPre prog state =
-  let preStore b = inferFrom state prog (name b) (from b)
-      preStores = map (\b -> (name b, preStore b)) $ snd prog
-  in fromList preStores
+postToPre = undefined --TODO: fix when adding PE support for processes
+-- postToPre prog state =
+--   let preStore b = inferFrom state prog (name b) (from b)
+--       preStores = map (\b -> (name b, preStore b)) $ snd prog
+--   in fromList preStores
 
 removeAssertionsProg :: (Ord a, Ord b) => State a b -> Program a b
                                        -> Program a b
-removeAssertionsProg preState (decl, pblocks) =
-  let cleanBlock b =
-        let initStore = get (name b) preState
-        in maybeToList $ removeAssertionsBlock initStore b
-      cleaning = compressPaths .
-                 changeConditionals .
-                 removeDeadBlocks .
-                 concatMap cleanBlock
-      cleanBody = cleaning . cleaning $ pblocks
-  in (decl, cleanBody)
+removeAssertionsProg = undefined --TODO: fix when adding PE support for processes
+-- removeAssertionsProg preState (decl, pblocks) =
+--   let cleanBlock b =
+--         let initStore = get (name b) preState
+--         in maybeToList $ removeAssertionsBlock initStore b
+--       cleaning = compressPaths .
+--                  changeConditionals .
+--                  removeDeadBlocks .
+--                  concatMap cleanBlock
+--       cleanBody = cleaning . cleaning $ pblocks
+--   in (decl, cleanBody)
 
 -- Remove all redundant assertions in a given block
 -- Fold over all steps so we don't need to work on normalized blocks
@@ -124,7 +126,8 @@ reduceExpr s (Op op e1 e2) =
      return (e, v)
 
 initPreState :: (Ord a, Ord b) => Program a b -> State a b
-initPreState (decl, prog) =
-  let anyStore = fromList $ map (\n -> (n, Any)) $ allVars decl
-      preState = fromList $ map (\b -> (name b, Just anyStore)) prog
-  in preState
+initPreState = undefined --TODO: fix when adding PE support for processes
+-- initPreState (decl, prog) =
+--   let anyStore = fromList $ map (\n -> (n, Any)) $ allVars decl
+--       preState = fromList $ map (\b -> (name b, Just anyStore)) prog
+--   in preState

--- a/src/Assertions/Impl/Removal.hs
+++ b/src/Assertions/Impl/Removal.hs
@@ -46,7 +46,7 @@ removeAssertionsBi prog =
 
 postToPre :: (Ord a, Ord b) => Program a b -> State a b
                             -> State a b
-postToPre = undefined --TODO: fix when adding PE support for processes
+postToPre = undefined --TODO: fix when adding PE support for procedures
 -- postToPre prog state =
 --   let preStore b = inferFrom state prog (name b) (from b)
 --       preStores = map (\b -> (name b, preStore b)) $ snd prog
@@ -54,7 +54,7 @@ postToPre = undefined --TODO: fix when adding PE support for processes
 
 removeAssertionsProg :: (Ord a, Ord b) => State a b -> Program a b
                                        -> Program a b
-removeAssertionsProg = undefined --TODO: fix when adding PE support for processes
+removeAssertionsProg = undefined --TODO: fix when adding PE support for procedures
 -- removeAssertionsProg preState (decl, pblocks) =
 --   let cleanBlock b =
 --         let initStore = get (name b) preState
@@ -126,7 +126,7 @@ reduceExpr s (Op op e1 e2) =
      return (e, v)
 
 initPreState :: (Ord a, Ord b) => Program a b -> State a b
-initPreState = undefined --TODO: fix when adding PE support for processes
+initPreState = undefined --TODO: fix when adding PE support for procedures
 -- initPreState (decl, prog) =
 --   let anyStore = fromList $ map (\n -> (n, Any)) $ allVars decl
 --       preState = fromList $ map (\b -> (name b, Just anyStore)) prog

--- a/src/Interpretation/Impl/Interpret.hs
+++ b/src/Interpretation/Impl/Interpret.hs
@@ -59,7 +59,7 @@ runProgram = undefined-- TODO: Implement when implementing interpreter
 -- Non-input values in a store are ignored
 -- output: program output and statistics
 runProgram' :: (Eq a, Show a) => Program a () -> Store -> LEM (Store, Stats)
-runProgram' = undefined --TODO: fix when adding PE support for processes
+runProgram' = undefined --TODO: fix when adding PE support for procedures
 -- runProgram' (decl, prog) store =
 --   do  entry <- raise $ getEntry prog
 --       let res = evalBlocks prog (output decl) runStore entry Nothing

--- a/src/Interpretation/Impl/Interpret.hs
+++ b/src/Interpretation/Impl/Interpret.hs
@@ -48,23 +48,25 @@ initStats = Stats 0 0 0
 -- Interpret a program with a given (verifiable wellformed) input
 -- output: program output and statistics
 runProgram :: (Eq a, Show a) => Program a () -> Store -> LEM (Store, Stats)
-runProgram (decl, prog) inpstore =
-  do  entry <- raise $ getEntry prog
-      store <- raise $ createStore decl inpstore
-      let res = evalBlocks prog (output decl) store entry Nothing
-      S.runStateT res initStats
+runProgram = undefined-- TODO: Implement when implementing interpreter
+-- runProgram (decl, prog) inpstore =
+--   do  entry <- raise $ getEntry prog
+--       store <- raise $ createStore decl inpstore
+--       let res = evalBlocks prog (output decl) store entry Nothing
+--       S.runStateT res initStats
 
 -- Interpret a program with a (possibly mallformed) input
 -- Non-input values in a store are ignored
 -- output: program output and statistics
 runProgram' :: (Eq a, Show a) => Program a () -> Store -> LEM (Store, Stats)
-runProgram' (decl, prog) store =
-  do  entry <- raise $ getEntry prog
-      let res = evalBlocks prog (output decl) runStore entry Nothing
-      S.runStateT res initStats
-  where
-    nilStore = fromList . map (\n -> (n, Nil)) $ nonInput decl
-    runStore = combine nilStore store
+runProgram' = undefined --TODO: fix when adding PE support for processes
+-- runProgram' (decl, prog) store =
+--   do  entry <- raise $ getEntry prog
+--       let res = evalBlocks prog (output decl) runStore entry Nothing
+--       S.runStateT res initStats
+--   where
+--     nilStore = fromList . map (\n -> (n, Nil)) $ nonInput decl
+--     runStore = combine nilStore store
 
 -- Create a proper store given an input store
 -- verifies that input store is wellformed
@@ -111,7 +113,8 @@ evalFrom s (Fi e (l1, ()) (l2, ())) (Just (l', ())) =
      let l = if truthy v then l1 else l2
      if l == l' then return ()
      else lift' $ Left "Assertion failed in Fi"
-evalFrom _ (Entry ()) Nothing = return ()
+-- TODO: fix
+-- evalFrom _ (Entry ()) Nothing = return ()
 evalFrom _ _ _ = lift' $ Left "Unexpected jump to entry, or wrong start"
 
 -- interpret a jump statement
@@ -122,7 +125,8 @@ evalJump s (If e (l1, ()) (l2, ())) = incJump >>
   do v <- lift' $ evalExpr s e
      return . Just $
       if truthy v then l1 else l2
-evalJump _ (Exit ()) = return Nothing
+-- TODO: fix
+-- evalJump _ (Exit ()) = return Nothing
 
 -- interpret multiple steps
 evalSteps :: Store -> [Step] -> SLEM Store

--- a/src/Inversion/Impl/Inverter.hs
+++ b/src/Inversion/Impl/Inverter.hs
@@ -4,10 +4,13 @@ import RL.AST
 
 -- invert a program
 invertProg :: Program a b -> Program a b
-invertProg (decl, p) = (invertDecl decl, map invertBlock p)
+invertProg  = map invertProc
 
-invertDecl :: VariableDecl -> VariableDecl
-invertDecl decl = decl {input = output decl, output = input decl}
+
+-- invert a proc
+invertProc :: Process a b -> Process a b
+invertProc = undefined --TODO: implement
+
 
 -- invert a block
 invertBlock :: Block a b -> Block a b
@@ -19,13 +22,13 @@ invertBlock Block {name = l, from = f, body = b, jump = j} = Block
 
 -- invert a come-from
 invertFrom :: ComeFrom a b -> Jump a b
-invertFrom (Entry s)          = Exit s
+invertFrom (Entry p s)          = Exit p s -- TODO: correct?
 invertFrom (From l)         = Goto l
 invertFrom (Fi e l1 l2) = If e l1 l2
 
 -- invert a jump
 invertJump :: Jump a b -> ComeFrom a b
-invertJump (Exit s)           = Entry s
+invertJump (Exit p s)           = Entry p s --TODO: correct?
 invertJump (Goto l)         = From l
 invertJump (If e l1 l2) = Fi e l1 l2
 

--- a/src/Inversion/Impl/Inverter.hs
+++ b/src/Inversion/Impl/Inverter.hs
@@ -28,7 +28,7 @@ invertFrom (Fi e l1 l2) = If e l1 l2
 
 -- invert a jump
 invertJump :: Jump a b -> ComeFrom a b
-invertJump (Exit p s)           = Entry p s --TODO: correct?
+invertJump (Exit p s)           = Entry p s
 invertJump (Goto l)         = From l
 invertJump (If e l1 l2) = Fi e l1 l2
 

--- a/src/Inversion/Impl/Inverter.hs
+++ b/src/Inversion/Impl/Inverter.hs
@@ -22,7 +22,7 @@ invertBlock Block {name = l, from = f, body = b, jump = j} = Block
 
 -- invert a come-from
 invertFrom :: ComeFrom a b -> Jump a b
-invertFrom (Entry p s)          = Exit p s -- TODO: correct?
+invertFrom (Entry p s)          = Exit p s
 invertFrom (From l)         = Goto l
 invertFrom (Fi e l1 l2) = If e l1 l2
 

--- a/src/Inversion/Impl/Inverter.hs
+++ b/src/Inversion/Impl/Inverter.hs
@@ -8,7 +8,7 @@ invertProg  = map invertProc
 
 
 -- invert a proc
-invertProc :: Process a b -> Process a b
+invertProc :: Procedure a b -> Procedure a b
 invertProc = undefined --TODO: implement
 
 

--- a/src/Normalize.hs
+++ b/src/Normalize.hs
@@ -6,12 +6,10 @@ import RL.Program
 import Data.List (sort, union, elemIndex)
 
 normalizeProgram :: Eq a => Program a () -> Program String ()
-normalizeProgram (decl, prog) = (normDecl decl, normBlocks prog)
+normalizeProgram prog = normProcs prog
 
--- Sort the variables because why not, it should not matter
-normDecl :: VariableDecl -> VariableDecl
-normDecl VariableDecl{input = inp, output = out, temp = tmp} =
-  VariableDecl (sort inp) (sort out) (sort tmp)
+normProcs :: Eq a => [Process a ()] -> [Process String ()]
+normProcs = undefined -- TODO fix when extending PE with support for processes.
 
 -- Make the label order and names uniform
 normBlocks :: Eq a => [Block a ()] -> [Block String ()]

--- a/src/Normalize.hs
+++ b/src/Normalize.hs
@@ -8,8 +8,8 @@ import Data.List (sort, union, elemIndex)
 normalizeProgram :: Eq a => Program a () -> Program String ()
 normalizeProgram prog = normProcs prog
 
-normProcs :: Eq a => [Process a ()] -> [Process String ()]
-normProcs = undefined -- TODO fix when extending PE with support for processes.
+normProcs :: Eq a => [Procedure a ()] -> [Procedure String ()]
+normProcs = undefined -- TODO fix when extending PE with support for procedures.
 
 -- Make the label order and names uniform
 normBlocks :: Eq a => [Block a ()] -> [Block String ()]

--- a/src/PE/AST2.hs
+++ b/src/PE/AST2.hs
@@ -6,12 +6,12 @@ import RL.Values
 import PE.SpecValues
 import PE.Preprocessing.Division
 
-type Program' label = [Process' label]
+type Program' label = [Procedure' label]
 
 data Explicated label = Regular label | Explicator label [Name]
   deriving (Eq, Show, Read)
 
-data Process' label = Process'{} --TODO: fix when adding PE support for processes
+data Procedure' label = Procedure'{} --TODO: fix when adding PE support for procedures
 
 data Block' label = Block'
   { name' :: label
@@ -58,10 +58,10 @@ data Expr' =
   deriving (Eq, Show, Read)
 
 mapProg' :: (a -> b) -> Program' a -> Program' b
-mapProg' f = map (mapProcess' f)
+mapProg' f = map (mapProcedure' f)
 
-mapProcess' :: (a -> b) -> Process' a -> Process' b
-mapProcess' = undefined --TODO: fix when adding PE support for processes
+mapProcedure' :: (a -> b) -> Procedure' a -> Procedure' b
+mapProcedure' = undefined --TODO: fix when adding PE support for procedures
 
 mapBlock' :: (a -> b) -> Block' a -> Block' b
 mapBlock' f b = b

--- a/src/PE/AST2.hs
+++ b/src/PE/AST2.hs
@@ -6,10 +6,12 @@ import RL.Values
 import PE.SpecValues
 import PE.Preprocessing.Division
 
-type Program' label = [Block' label]
+type Program' label = [Process' label]
 
 data Explicated label = Regular label | Explicator label [Name]
   deriving (Eq, Show, Read)
+
+data Process' label = Process'{} --TODO: fix when adding PE support for processes
 
 data Block' label = Block'
   { name' :: label
@@ -56,7 +58,10 @@ data Expr' =
   deriving (Eq, Show, Read)
 
 mapProg' :: (a -> b) -> Program' a -> Program' b
-mapProg' f = map (mapBlock' f)
+mapProg' f = map (mapProcess' f)
+
+mapProcess' :: (a -> b) -> Process' a -> Process' b
+mapProcess' = undefined --TODO: fix when adding PE support for processes
 
 mapBlock' :: (a -> b) -> Block' a -> Block' b
 mapBlock' f b = b

--- a/src/PE/Preprocessing/Division.hs
+++ b/src/PE/Preprocessing/Division.hs
@@ -46,6 +46,7 @@ makeDiv store decl =
 
 startingDiv :: (Ord a) => NormProgram a -> PWDivision a
                               -> Division
-startingDiv (_, p) pwd =
-  let n = nname $ getNEntryBlock p
-  in fst $ get n pwd
+startingDiv p pwd =
+  undefined -- TODO: fix
+  -- let n = nname $ getNEntryBlock p
+  -- in fst $ get n pwd

--- a/src/PE/Preprocessing/Division.hs
+++ b/src/PE/Preprocessing/Division.hs
@@ -47,6 +47,6 @@ makeDiv store decl =
 startingDiv :: (Ord a) => NormProgram a -> PWDivision a
                               -> Division
 startingDiv p pwd =
-   undefined --TODO: fix when adding PE support for processes
+   undefined --TODO: fix when adding PE support for procedures
   -- let n = nname $ getNEntryBlock p
   -- in fst $ get n pwd

--- a/src/PE/Preprocessing/Impl/Annotate.hs
+++ b/src/PE/Preprocessing/Impl/Annotate.hs
@@ -14,7 +14,7 @@ annotateProg d = map (annotateProcess d)
 
 -- Annotate a normalized process
 annotateProcess :: Ord a => PWDivision a -> NormProcess a -> Process' a
-annotateProcess = undefined --TODO: fix when adding PE support for processes
+annotateProcess = undefined --TODO: fix when adding PE support for procedures
 -- Annotate a normalized block
 annotateBlock :: Ord a => PWDivision a -> NormBlock a -> Block' a
 annotateBlock pwd b =

--- a/src/PE/Preprocessing/Impl/Annotate.hs
+++ b/src/PE/Preprocessing/Impl/Annotate.hs
@@ -48,7 +48,7 @@ annotateStep _ _ Skip = Skip' BTStatic
 
 -- Annotate a come-from
 annotateFrom :: Division -> ComeFrom a () -> ComeFrom' a
-annotateFrom  = undefined --TODO: fix when adding PE support for processes
+annotateFrom  = undefined --TODO: fix when adding PE support for procedures
 -- annotateFrom _ (Entry ()) = Entry'
 -- annotateFrom _ (From (l, ())) = From' l
 -- annotateFrom d (Fi e (l1, ()) (l2, ())) =

--- a/src/PE/Preprocessing/Impl/Annotate.hs
+++ b/src/PE/Preprocessing/Impl/Annotate.hs
@@ -45,19 +45,21 @@ annotateStep _ _ Skip = Skip' BTStatic
 
 -- Annotate a come-from
 annotateFrom :: Division -> ComeFrom a () -> ComeFrom' a
-annotateFrom _ (Entry ()) = Entry'
-annotateFrom _ (From (l, ())) = From' l
-annotateFrom d (Fi e (l1, ()) (l2, ())) =
-  let (e', btType) = annotateExp d e
-  in Fi' btType e' l1 l2
+annotateFrom = undefined -- TODO: fix
+-- annotateFrom _ (Entry ()) = Entry'
+-- annotateFrom _ (From (l, ())) = From' l
+-- annotateFrom d (Fi e (l1, ()) (l2, ())) =
+--   let (e', btType) = annotateExp d e
+--   in Fi' btType e' l1 l2
 
 -- Annotate a jump
 annotateJump :: Division -> Jump a () -> Jump' a
-annotateJump _ (Exit ()) = Exit'
-annotateJump _ (Goto (l, ())) = Goto' l
-annotateJump d (If e (l1, ()) (l2, ())) =
-  let (e', btType) = annotateExp d e
-  in If' btType e' l1 l2
+annotateJump = undefined -- TODO: fix
+-- annotateJump _ (Exit ()) = Exit'
+-- annotateJump _ (Goto (l, ())) = Goto' l
+-- annotateJump d (If e (l1, ()) (l2, ())) =
+--   let (e', btType) = annotateExp d e
+--   in If' btType e' l1 l2
 
 -- Annotate patterns with precision
 annotatePats :: Division -> Division -> Pattern -> Pattern -> (Pattern', Pattern', Level)

--- a/src/PE/Preprocessing/Impl/Annotate.hs
+++ b/src/PE/Preprocessing/Impl/Annotate.hs
@@ -10,8 +10,11 @@ import PE.Preprocessing.Division
 
 -- Annotate a normalized program
 annotateProg :: Ord a => PWDivision a -> NormProgram a -> Program' a
-annotateProg d (_, p)= map (annotateBlock d) p
+annotateProg d = map (annotateProcess d)
 
+-- Annotate a normalized process
+annotateProcess :: Ord a => PWDivision a -> NormProcess a -> Process' a
+annotateProcess = undefined --TODO: fix when adding PE support for processes
 -- Annotate a normalized block
 annotateBlock :: Ord a => PWDivision a -> NormBlock a -> Block' a
 annotateBlock pwd b =

--- a/src/PE/Preprocessing/Impl/Explicicator.hs
+++ b/src/PE/Preprocessing/Impl/Explicicator.hs
@@ -13,24 +13,26 @@ import Data.Maybe (catMaybes)
 
 -- add explicators for a given RL2 program
 explicate :: Ord a => PWDivision a -> Program' a -> (a -> Int -> a) -> Program' (Explicated a)
-explicate pwd p f =
-  let (renames', blocks') = unzip $ map (explicateBlock pwd p f) p
-      (renames, blocks) = (concat renames', concat blocks')
-  in fixComeFroms renames blocks
+explicate = undefined --TODO: fix when adding PE support for processes
+-- explicate pwd p f =
+--   let (renames', blocks') = unzip $ map (explicateBlock pwd p f) p
+--       (renames, blocks) = (concat renames', concat blocks')
+--   in fixComeFroms renames blocks
 
 -- fix come-froms for blocks where an explicator was inserted before it
 fixComeFroms :: Ord a => [(Explicated a, (Explicated a, Explicated a))] -> [Block' (Explicated a)]
                      -> Program' (Explicated a)
-fixComeFroms [] bs = bs
-fixComeFroms ((l, (target, replace)) : ls) bs =
-  let bs' = map (\b -> if name' b == l then fixBlock b else b) bs
-  in fixComeFroms ls bs'
-  where
-    fixBlock b@Block'{from' = k} = b{from' = fixFrom k}
-    fixLabel l' = if l' == target then replace else l'
-    fixFrom Entry' = Entry'
-    fixFrom (From' l') = From' (fixLabel l')
-    fixFrom (Fi' e t l1 l2) = Fi' e t (fixLabel l1) (fixLabel l2)
+fixComeFroms = undefined --TODO: fix when adding PE support for processes
+-- fixComeFroms [] bs = bs
+-- fixComeFroms ((l, (target, replace)) : ls) bs =
+--   let bs' = map (\b -> if name' b == l then fixBlock b else b) bs
+--   in fixComeFroms ls bs'
+--   where
+--     fixBlock b@Block'{from' = k} = b{from' = fixFrom k}
+--     fixLabel l' = if l' == target then replace else l'
+--     fixFrom Entry' = Entry'
+--     fixFrom (From' l') = From' (fixLabel l')
+--     fixFrom (Fi' e t l1 l2) = Fi' e t (fixLabel l1) (fixLabel l2)
 
 -- "Explicate" a single block
 -- returning the block along with possible explicators
@@ -76,14 +78,15 @@ toBeExplicated pwd d j =
 -- integer used to distinguish between branches
 createExplicator :: Eq a => Program' a -> (a -> Int -> a) -> a -> (a, [Name]) -> Int
                          -> (a, Maybe (Block' (Explicated a)))
-createExplicator _ _ _ (dest, []) _ = (dest, Nothing)
-createExplicator p f src (dest, ns) idx = (dest, return (Block'
-  { name' = Explicator (f src idx) ns
-  , initDiv = sets ns BTStatic . initDiv $ getBlockUnsafe' p dest
-  , from' = From' $ Regular src
-  , body' = map Generalize ns
-  , jump' = Goto' $ Regular dest
-  }))
+createExplicator = undefined --TODO: fix when adding PE support for processes
+-- createExplicator _ _ _ (dest, []) _ = (dest, Nothing)
+-- createExplicator p f src (dest, ns) idx = (dest, return (Block'
+--   { name' = Explicator (f src idx) ns
+--   , initDiv = sets ns BTStatic . initDiv $ getBlockUnsafe' p dest
+--   , from' = From' $ Regular src
+--   , body' = map Generalize ns
+--   , jump' = Goto' $ Regular dest
+--   }))
 
 -- annotate jump labels and distinguish between paths
 mapJumpInt :: (a -> Int -> b) -> Jump' a -> Jump' b

--- a/src/PE/Preprocessing/Impl/Explicicator.hs
+++ b/src/PE/Preprocessing/Impl/Explicicator.hs
@@ -13,7 +13,7 @@ import Data.Maybe (catMaybes)
 
 -- add explicators for a given RL2 program
 explicate :: Ord a => PWDivision a -> Program' a -> (a -> Int -> a) -> Program' (Explicated a)
-explicate = undefined --TODO: fix when adding PE support for processes
+explicate = undefined --TODO: fix when adding PE support for procedures
 -- explicate pwd p f =
 --   let (renames', blocks') = unzip $ map (explicateBlock pwd p f) p
 --       (renames, blocks) = (concat renames', concat blocks')
@@ -22,7 +22,7 @@ explicate = undefined --TODO: fix when adding PE support for processes
 -- fix come-froms for blocks where an explicator was inserted before it
 fixComeFroms :: Ord a => [(Explicated a, (Explicated a, Explicated a))] -> [Block' (Explicated a)]
                      -> Program' (Explicated a)
-fixComeFroms = undefined --TODO: fix when adding PE support for processes
+fixComeFroms = undefined --TODO: fix when adding PE support for procedures
 -- fixComeFroms [] bs = bs
 -- fixComeFroms ((l, (target, replace)) : ls) bs =
 --   let bs' = map (\b -> if name' b == l then fixBlock b else b) bs
@@ -78,7 +78,7 @@ toBeExplicated pwd d j =
 -- integer used to distinguish between branches
 createExplicator :: Eq a => Program' a -> (a -> Int -> a) -> a -> (a, [Name]) -> Int
                          -> (a, Maybe (Block' (Explicated a)))
-createExplicator = undefined --TODO: fix when adding PE support for processes
+createExplicator = undefined --TODO: fix when adding PE support for procedures
 -- createExplicator _ _ _ (dest, []) _ = (dest, Nothing)
 -- createExplicator p f src (dest, ns) idx = (dest, return (Block'
 --   { name' = Explicator (f src idx) ns

--- a/src/PE/Preprocessing/Impl/Normalize.hs
+++ b/src/PE/Preprocessing/Impl/Normalize.hs
@@ -5,28 +5,37 @@ import RL.Program
 
 -- normalize a program
 normalize :: Eq a => a -> a -> Program a () -> (a -> Int -> a) -> NormProgram a
-normalize entry exit (decl, prog) f = (decl, pad entry exit $ concatMap (normalizeBlock prog f) prog)
+normalize entry exit  procs f = ( padProc entry exit $ concatMap (normalizeProc procs f) procs)
+
+--normalize a process
+normalizeProc :: Eq a => [Process a ()] -> (a -> Int -> a) -> Process a () -> [NormProcess a]
+normalizeProc = undefined -- TODO: extend with support for processes
+
+--padProc - dummy func to allow compilation until support for PE with procs is added.
+padProc :: Eq a => a -> a -> [NormProcess a] -> [NormProcess a]
+padProc = undefined
 
 -- add an extra nop block in the beginning of a program
 -- for room for explicator in beginning of program
 pad :: Eq a => a -> a -> [NormBlock a] -> [NormBlock a]
-pad entryLabel exitLabel prog =
-  let entryBlock = getNEntryBlock prog
-      exitBlock = getNExitBlock prog
-      l1 = nname entryBlock
-      l2 = nname exitBlock
-      padding1 = NormBlock entryLabel (Entry ()) Skip (Goto (l1, ()))
-      padding2 = NormBlock exitLabel (From (l2, ())) Skip (Exit ())
-  in if l1 /= l2
-     then let rest = filter (\b -> nname b `notElem` [l1, l2]) prog
-              entry' = entryBlock{nfrom = From (entryLabel, ())}
-              exit' = exitBlock{njump = Goto (exitLabel, ())}
-          in [padding1, entry'] ++ rest ++ [exit', padding2]
-     else [ padding1
-          , exitBlock{ nfrom = From (entryLabel, ())
-                     , njump = Goto (entryLabel, ())
-                     }
-          , padding2]
+pad = undefined -- TODO: fix implementation to support entry and exit blocks taking a pattern as argument.
+-- pad entryLabel exitLabel prog =
+--   let entryBlock = getNEntryBlock prog
+--       exitBlock = getNExitBlock prog
+--       l1 = nname entryBlock
+--       l2 = nname exitBlock
+--       padding1 = NormBlock entryLabel (Entry ()) Skip (Goto (l1, ()))
+--       padding2 = NormBlock exitLabel (From (l2, ())) Skip (Exit ())
+--   in if l1 /= l2
+--      then let rest = filter (\b -> nname b `notElem` [l1, l2]) prog
+--               entry' = entryBlock{nfrom = From (entryLabel, ())}
+--               exit' = exitBlock{njump = Goto (exitLabel, ())}
+--           in [padding1, entry'] ++ rest ++ [exit', padding2]
+--      else [ padding1
+--           , exitBlock{ nfrom = From (entryLabel, ())
+--                      , njump = Goto (entryLabel, ())
+--                      }
+--           , padding2]
 
 -- normalize a block, transforming each step into its own block
 normalizeBlock :: Eq a => [Block a ()] -> (a -> Int -> a) -> Block a () -> [NormBlock a]
@@ -43,7 +52,7 @@ normalizeBlock prog f Block{name = (l, ()), from = k, body = b, jump = j} =
 normalizeFrom :: (Eq a, Eq b) => [Block a b] -> (a -> Int -> a) -> ComeFrom a b -> ComeFrom a b
 normalizeFrom prog f k =
   case k of
-    Entry s -> Entry s
+    Entry p s -> Entry p s --TODO: is pattern unaltered?
     From l -> From $ transformLab l
     Fi e l1 l2 -> Fi e (transformLab l1) (transformLab l2)
   where
@@ -54,6 +63,6 @@ normalizeFrom prog f k =
 
 -- point jump labels to correct normalized block
 normalizeJump :: (a -> Int -> a) -> Jump a b -> Jump a b
-normalizeJump _ (Exit s) = Exit s
+normalizeJump _ (Exit p s) = Exit p s -- TODO: is pattern unaltered?
 normalizeJump f (Goto (l,s)) = Goto (f l 1, s)
 normalizeJump f (If e (l1, s1) (l2, s2)) = If e (f l1 1, s1) (f l2 1, s2)

--- a/src/PE/Preprocessing/Impl/Normalize.hs
+++ b/src/PE/Preprocessing/Impl/Normalize.hs
@@ -7,12 +7,12 @@ import RL.Program
 normalize :: Eq a => a -> a -> Program a () -> (a -> Int -> a) -> NormProgram a
 normalize entry exit  procs f = ( padProc entry exit $ concatMap (normalizeProc procs f) procs)
 
---normalize a process
-normalizeProc :: Eq a => [Process a ()] -> (a -> Int -> a) -> Process a () -> [NormProcess a]
-normalizeProc = undefined -- TODO: extend with support for processes
+--normalize a procedure
+normalizeProc :: Eq a => [Procedure a ()] -> (a -> Int -> a) -> Procedure a () -> [NormProcedure a]
+normalizeProc = undefined -- TODO: extend with support for procedures
 
 --padProc - dummy func to allow compilation until support for PE with procs is added.
-padProc :: Eq a => a -> a -> [NormProcess a] -> [NormProcess a]
+padProc :: Eq a => a -> a -> [NormProcedure a] -> [NormProcedure a]
 padProc = undefined
 
 -- add an extra nop block in the beginning of a program

--- a/src/PE/Preprocessing/Impl/Pointwise.hs
+++ b/src/PE/Preprocessing/Impl/Pointwise.hs
@@ -12,7 +12,7 @@ import PE.Preprocessing.Division
 -- create initial PW division for a given starting division
 -- all divisions are fully static except entry block
 initPWDiv :: Ord a => NormProgram a -> Division -> PWDivision a
-initPWDiv = undefined --TODO: fix when adding PE support for processes
+initPWDiv = undefined --TODO: fix when adding PE support for procedures
 -- initPWDiv (decl, prog) d =
 --   let lStart = nname $ getNEntryBlock prog
 --       ls = map nname prog
@@ -23,7 +23,7 @@ initPWDiv = undefined --TODO: fix when adding PE support for processes
 
 -- make PW division congruent
 makeCongruentPW :: Ord a => NormProgram a -> PWDivision a -> PWDivision a
-makeCongruentPW = undefined --TODO: fix when adding PE support for processes
+makeCongruentPW = undefined --TODO: fix when adding PE support for procedures
 -- makeCongruentPW (_, prog) d = workQueue prog d $ map nname prog
 
 -- fix-point iteration powered by a work-queue

--- a/src/PE/Preprocessing/Impl/Pointwise.hs
+++ b/src/PE/Preprocessing/Impl/Pointwise.hs
@@ -12,17 +12,19 @@ import PE.Preprocessing.Division
 -- create initial PW division for a given starting division
 -- all divisions are fully static except entry block
 initPWDiv :: Ord a => NormProgram a -> Division -> PWDivision a
-initPWDiv (decl, prog) d =
-  let lStart = nname $ getNEntryBlock prog
-      ls = map nname prog
-      dstatic = makeStaticDiv decl
-      actualDiv l = (l, if l == lStart then (d, dstatic) else dup dstatic)
-      pairs = map actualDiv ls
-  in fromList pairs
+initPWDiv = undefined --TODO: fix when adding PE support for processes
+-- initPWDiv (decl, prog) d =
+--   let lStart = nname $ getNEntryBlock prog
+--       ls = map nname prog
+--       dstatic = makeStaticDiv decl
+--       actualDiv l = (l, if l == lStart then (d, dstatic) else dup dstatic)
+--       pairs = map actualDiv ls
+--   in fromList pairs
 
 -- make PW division congruent
 makeCongruentPW :: Ord a => NormProgram a -> PWDivision a -> PWDivision a
-makeCongruentPW (_, prog) d = workQueue prog d $ map nname prog
+makeCongruentPW = undefined --TODO: fix when adding PE support for processes
+-- makeCongruentPW (_, prog) d = workQueue prog d $ map nname prog
 
 -- fix-point iteration powered by a work-queue
 workQueue :: Ord a => [NormBlock a] -> PWDivision a -> [a] -> PWDivision a

--- a/src/PE/Preprocessing/Impl/Uniform.hs
+++ b/src/PE/Preprocessing/Impl/Uniform.hs
@@ -16,11 +16,12 @@ type ST a = S.State Division a
 
 -- Create a congruent uniform division for a program
 congruentUniformDiv :: Ord a => NormProgram a -> Division -> PWDivision a
-congruentUniformDiv (decl, p) d =
-  let congruentDiv = makeCongruent (decl, p) d
-      ls = map nname p
-      pairs = map (\l -> (l, (congruentDiv, congruentDiv))) ls
-  in fromList pairs
+congruentUniformDiv p d =
+  undefined -- TODO: fix
+  -- let congruentDiv = makeCongruent (decl, p) d
+  --     ls = map nname p
+  --     pairs = map (\l -> (l, (congruentDiv, congruentDiv))) ls
+  -- in fromList pairs
 
 -- Fix-point iteration for division
 makeCongruent :: NormProgram a -> Division -> Division
@@ -33,7 +34,8 @@ makeCongruent p = fixed (S.execState $ checkProg p)
 -- The Division is preserved in the state-monad for fewer arguments passed
 -- and the division will grow increasingly dynamic throughout the iteration
 checkProg :: NormProgram a -> ST ()
-checkProg (decl, p) = mapM_ (checkBlock decl) p
+checkProg p = undefined -- TODO: fix
+    -- mapM_ (checkBlock decl) p
 
 -- Iterate through block
 -- Only check step as control flow does not affect BTA

--- a/src/PE/Preprocessing/Impl/Uniform.hs
+++ b/src/PE/Preprocessing/Impl/Uniform.hs
@@ -17,7 +17,7 @@ type ST a = S.State Division a
 -- Create a congruent uniform division for a program
 congruentUniformDiv :: Ord a => NormProgram a -> Division -> PWDivision a
 congruentUniformDiv p d =
-   undefined --TODO: fix when adding PE support for processes
+   undefined --TODO: fix when adding PE support for procedures
   -- let congruentDiv = makeCongruent (decl, p) d
   --     ls = map nname p
   --     pairs = map (\l -> (l, (congruentDiv, congruentDiv))) ls
@@ -34,7 +34,7 @@ makeCongruent p = fixed (S.execState $ checkProg p)
 -- The Division is preserved in the state-monad for fewer arguments passed
 -- and the division will grow increasingly dynamic throughout the iteration
 checkProg :: NormProgram a -> ST ()
-checkProg p  = undefined --TODO: fix when adding PE support for processes
+checkProg p  = undefined --TODO: fix when adding PE support for procedures
     -- mapM_ (checkBlock decl) p
 
 -- Iterate through block

--- a/src/PE/Preprocessing/Impl/Wellformed2.hs
+++ b/src/PE/Preprocessing/Impl/Wellformed2.hs
@@ -8,7 +8,7 @@ import PE.SpecValues
 import PE.Preprocessing.Division
 
 wellformedProg' :: Ord a => PWDivision a -> Program' a -> EM ()
-wellformedProg' = undefined --TODO: fix when adding PE support for processes
+wellformedProg' = undefined --TODO: fix when adding PE support for procedures
 -- wellformedProg' pwd = mapM_ wellformedBlock'
 --   where
 --     wellformedBlock' b = do

--- a/src/PE/Preprocessing/Impl/Wellformed2.hs
+++ b/src/PE/Preprocessing/Impl/Wellformed2.hs
@@ -8,13 +8,14 @@ import PE.SpecValues
 import PE.Preprocessing.Division
 
 wellformedProg' :: Ord a => PWDivision a -> Program' a -> EM ()
-wellformedProg' pwd = mapM_ wellformedBlock'
-  where
-    wellformedBlock' b = do
-      let (d1, d2) = get (name' b) pwd
-      wellformedFrom' d1 $ from' b
-      mapM_ (wellformedStep' d1 d2) $ body' b
-      wellformedJump' d2 $ jump' b
+wellformedProg' = undefined --TODO: fix when adding PE support for processes
+-- wellformedProg' pwd = mapM_ wellformedBlock'
+--   where
+--     wellformedBlock' b = do
+--       let (d1, d2) = get (name' b) pwd
+--       wellformedFrom' d1 $ from' b
+--       mapM_ (wellformedStep' d1 d2) $ body' b
+--       wellformedJump' d2 $ jump' b
 
 wellformedFrom' :: Division -> ComeFrom' a -> EM ()
 wellformedFrom' _ Entry'         = return ()

--- a/src/PE/Specialization/Impl/PostProcessing.hs
+++ b/src/PE/Specialization/Impl/PostProcessing.hs
@@ -128,7 +128,7 @@ mergeExplicators annotateExpl p =
 -- Merge all residual exits into a single one and
 -- generalize the static output variables that differ between exits
 mergeExits :: VariableDecl -> (a -> Int -> Int -> a) -> Program a SpecStore -> (Program a SpecStore, [(Name, SpecValue)])
-mergeExits = undefined --TODO: fix when adding PE support for processes
+mergeExits = undefined --TODO: fix when adding PE support for procedures
 -- mergeExits origdecl annotateExit (VariableDecl{input = inp, output = out, temp = tmp}, p) =
 --   let (exits, rest) = L.partition isExit p
 --       stores = map (toList . getExitStore) exits

--- a/src/PE/Specialization/Impl/PostProcessing.hs
+++ b/src/PE/Specialization/Impl/PostProcessing.hs
@@ -144,7 +144,7 @@ mergeExits origdecl annotateExit (VariableDecl{input = inp, output = out, temp =
   where
     getExitStore b =
       case jump b of
-        Exit s -> s
+        Exit p s -> s --TODO: handle exit pattern
         _ -> undefined
     initStep b n =
       let v = toVal $ get n (getExitStore b)

--- a/src/PE/Specialization/Impl/PostProcessing.hs
+++ b/src/PE/Specialization/Impl/PostProcessing.hs
@@ -128,34 +128,35 @@ mergeExplicators annotateExpl p =
 -- Merge all residual exits into a single one and
 -- generalize the static output variables that differ between exits
 mergeExits :: VariableDecl -> (a -> Int -> Int -> a) -> Program a SpecStore -> (Program a SpecStore, [(Name, SpecValue)])
-mergeExits origdecl annotateExit (VariableDecl{input = inp, output = out, temp = tmp}, p) =
-  let (exits, rest) = L.partition isExit p
-      stores = map (toList . getExitStore) exits
-      ns = map fst $ head stores
-      vals = map (map snd) stores
-      tpls = zip ns $ L.transpose vals
-      toFix =  map fst $ filter (\(_,vs) -> any (head vs /=) vs) tpls
-      initialized = map (initFix toFix) exits
-      explGroups = zipWith (\b i -> (b, i, i)) initialized [1..]
-      (exit, _, _, _, extras) = mergeBlocks' toFix explGroups
-      newDecl = VariableDecl inp (out ++ toFix) (filter (`notElem` toFix) tmp)
-      finalState = filter (\(n,_) -> n `notElem` toFix && n `elem` output origdecl) $ head stores
-  in ((newDecl, rest ++ extras ++ [exit] ), finalState)
-  where
-    getExitStore b =
-      case jump b of
-        Exit p s -> s --TODO: handle exit pattern
-        _ -> undefined
-    initStep b n =
-      let v = toVal $ get n (getExitStore b)
-      in case v of
-          Nil -> []
-          _ -> [Replacement (QVar n) (QConst v)]
-    initFix toFix b =
-      let initSteps = concatMap (initStep b) toFix
-      in b{body = body b ++ initSteps}
-    annotateExit' b = annotateExit $ label b
-    mergeBlocks' = mergeBlocks annotateExit' getExitStore
+mergeExits = undefined --TODO: fix when adding PE support for processes
+-- mergeExits origdecl annotateExit (VariableDecl{input = inp, output = out, temp = tmp}, p) =
+--   let (exits, rest) = L.partition isExit p
+--       stores = map (toList . getExitStore) exits
+--       ns = map fst $ head stores
+--       vals = map (map snd) stores
+--       tpls = zip ns $ L.transpose vals
+--       toFix =  map fst $ filter (\(_,vs) -> any (head vs /=) vs) tpls
+--       initialized = map (initFix toFix) exits
+--       explGroups = zipWith (\b i -> (b, i, i)) initialized [1..]
+--       (exit, _, _, _, extras) = mergeBlocks' toFix explGroups
+--       newDecl = VariableDecl inp (out ++ toFix) (filter (`notElem` toFix) tmp)
+--       finalState = filter (\(n,_) -> n `notElem` toFix && n `elem` output origdecl) $ head stores
+--   in ((newDecl, rest ++ extras ++ [exit] ), finalState)
+--   where
+--     getExitStore b =
+--       case jump b of
+--         Exit p s -> s --TODO: handle exit pattern
+--         _ -> undefined
+--     initStep b n =
+--       let v = toVal $ get n (getExitStore b)
+--       in case v of
+--           Nil -> []
+--           _ -> [Replacement (QVar n) (QConst v)]
+--     initFix toFix b =
+--       let initSteps = concatMap (initStep b) toFix
+--       in b{body = body b ++ initSteps}
+--     annotateExit' b = annotateExit $ label b
+--     mergeBlocks' = mergeBlocks annotateExit' getExitStore
 
 -- Generalized block merging
 mergeBlocks :: (Block a SpecStore -> Int -> Int -> a) -> (Block a SpecStore -> SpecStore) -> [Name] -> [(Block a SpecStore, Int, Int)]
@@ -256,7 +257,7 @@ compressPaths p =
             in chain : chainBlocks (new ++ ls) (l : seen)
           Nothing -> chainBlocks ls seen
     getChain b = case jump b of
-      Exit _ -> ([b], [])
+      Exit _ _ -> ([b], []) --TODO: handle exit pattern
       If _ l1 l2 -> ([b], [l1, l2])
       Goto l -> case getBlock p l of
                   Just b'@Block {from = From l'} | name b == l' ->

--- a/src/PE/Specialization/Impl/Specialize.hs
+++ b/src/PE/Specialization/Impl/Specialize.hs
@@ -95,23 +95,24 @@ specBlock entry decl s b origin =
 
 specFrom :: Eq a => a -> SpecStore -> ComeFrom' a -> (a, SpecStore)
                  -> EM (ComeFrom a (Maybe SpecStore))
-specFrom _ _ (From' l) origin
-  | l `isFrom` origin = return (From (l, Just . snd $ origin))
-  | otherwise         = Left "Invalid jump to an unconditional from."
-specFrom x s Entry' (l, _)
-  | l == x    = return $ Entry $ Just s
-  | otherwise = Left "Invalid jump to entry block."
-specFrom _ s (Fi' BTStatic e l1 l2) origin =
-  do v <- getValue e s
-     let l = if truthy v then l1 else l2
-     if l `isFrom` origin
-      then return . From $ annotate l origin
-      else Left "Jump not from expected block."
-specFrom _ s (Fi' BTDynamic e l1 l2) origin
-  | l1 `isFrom` origin || l2 `isFrom` origin =
-    do e' <- getExpr e s
-       return $ Fi e' (annotate l1 origin) (annotate l2 origin)
-  | otherwise = Left "Jump not from either of the expected blocks."
+specFrom = undefined --TODO: fix when adding PE support for processes
+-- specFrom _ _ (From' l) origin
+--   | l `isFrom` origin = return (From (l, Just . snd $ origin))
+--   | otherwise         = Left "Invalid jump to an unconditional from."
+-- specFrom x s Entry' (l, _)
+--   | l == x    = return $ Entry $ Just s
+--   | otherwise = Left "Invalid jump to entry block."
+-- specFrom _ s (Fi' BTStatic e l1 l2) origin =
+--   do v <- getValue e s
+--      let l = if truthy v then l1 else l2
+--      if l `isFrom` origin
+--       then return . From $ annotate l origin
+--       else Left "Jump not from expected block."
+-- specFrom _ s (Fi' BTDynamic e l1 l2) origin
+--   | l1 `isFrom` origin || l2 `isFrom` origin =
+--     do e' <- getExpr e s
+--        return $ Fi e' (annotate l1 origin) (annotate l2 origin)
+--   | otherwise = Left "Jump not from either of the expected blocks."
 
 isFrom :: Eq a => a -> (a, SpecStore) -> Bool
 isFrom l (l', _) = l == l' -- "l = label(l')" in judgements
@@ -122,25 +123,26 @@ annotate l (l', s) | l == l'   = (l, Just s)
 
 specJump :: SpecStore -> VariableDecl -> Jump' a
             -> EM (Jump a (Maybe SpecStore), [Point a])
-specJump s decl Exit' =
-  do let checkable = staticNonOutput decl s
-     vs <- mapM (`find` s) checkable
-     let pairs = zip checkable vs
-     let offendingVars = filter (\(_,v) -> v /= Static Nil) pairs
-     case offendingVars of
-      [] -> return (Exit (Just s), [])
-      ((n,_):_) -> Left $ "Non-nil non-output variable \"" ++ n ++ "\" at exit"
-specJump s _ (Goto' l) =
-   return (Goto (l, Just s), [(l, s)])
-specJump s _ (If' BTDynamic e l1 l2) =
-  do e' <- getExpr e s;
-     return (If e' (l1, Just s) (l2, Just s), [(l1, s), (l2, s)])
-specJump s _ (If' BTStatic e l1 l2) =
-  do v <- getValue e s
-     return $
-      if truthy v
-        then (Goto (l1, Just s), [(l1, s)])
-        else (Goto (l2, Just s), [(l2, s)])
+specJump = undefined --TODO: fix when adding PE support for processes
+-- specJump s decl Exit' =
+--   do let checkable = staticNonOutput decl s
+--      vs <- mapM (`find` s) checkable
+--      let pairs = zip checkable vs
+--      let offendingVars = filter (\(_,v) -> v /= Static Nil) pairs
+--      case offendingVars of
+--       [] -> return (Exit (Just s), [])
+--       ((n,_):_) -> Left $ "Non-nil non-output variable \"" ++ n ++ "\" at exit"
+-- specJump s _ (Goto' l) =
+--    return (Goto (l, Just s), [(l, s)])
+-- specJump s _ (If' BTDynamic e l1 l2) =
+--   do e' <- getExpr e s;
+--      return (If e' (l1, Just s) (l2, Just s), [(l1, s), (l2, s)])
+-- specJump s _ (If' BTStatic e l1 l2) =
+--   do v <- getValue e s
+--      return $
+--       if truthy v
+--         then (Goto (l1, Just s), [(l1, s)])
+--         else (Goto (l2, Just s), [(l2, s)])
 
 specSteps :: SpecStore -> [Step'] -> EM (SpecStore, [Step])
 specSteps s [] = return (s, [])

--- a/src/PE/Specialization/Impl/Specialize.hs
+++ b/src/PE/Specialization/Impl/Specialize.hs
@@ -22,7 +22,7 @@ type Pending a = [(Point a, Point a)]
 type Seen a = Pending a
 
 specialize :: (Eq a, Show a) => VariableDecl -> Program' a -> SpecStore -> a -> LEM (Program a (Maybe SpecStore))
-specialize = undefined --TODO: fix when adding PE support for processes
+specialize = undefined --TODO: fix when adding PE support for procedures
 -- specialize decl prog s entry =
 --   do
 --      b <- raise $ getEntry' prog
@@ -32,7 +32,7 @@ specialize = undefined --TODO: fix when adding PE support for processes
 --      return (decl', reverse res) -- Reverse for nicer ordering of blocks
 
 specDecl :: VariableDecl -> Program' a -> EM VariableDecl
-specDecl = undefined --TODO: fix when adding PE support for processes
+specDecl = undefined --TODO: fix when adding PE support for procedures
 -- specDecl decl p =
 --   do inBlock <- getEntryBlock' p
 --      outBlock <- getExitBlock' p
@@ -48,7 +48,7 @@ specDecl = undefined --TODO: fix when adding PE support for processes
 
 specProg :: (Eq a, Show a) => a -> VariableDecl -> Program' a -> Pending a -> Seen a -> [Block a (Maybe SpecStore)]
                             -> LEM [Block a (Maybe SpecStore)]
-specProg = undefined --TODO: fix when adding PE support for processes
+specProg = undefined --TODO: fix when adding PE support for procedures
 -- specProg _ _ _ [] _ res =
 --   do logM "Specialization done."; return res
 -- specProg entry decl prog (p:ps) seen res
@@ -98,7 +98,7 @@ specBlock entry decl s b origin =
 
 specFrom :: Eq a => a -> SpecStore -> ComeFrom' a -> (a, SpecStore)
                  -> EM (ComeFrom a (Maybe SpecStore))
-specFrom = undefined --TODO: fix when adding PE support for processes
+specFrom = undefined --TODO: fix when adding PE support for procedures
 -- specFrom _ _ (From' l) origin
 --   | l `isFrom` origin = return (From (l, Just . snd $ origin))
 --   | otherwise         = Left "Invalid jump to an unconditional from."
@@ -126,7 +126,7 @@ annotate l (l', s) | l == l'   = (l, Just s)
 
 specJump :: SpecStore -> VariableDecl -> Jump' a
             -> EM (Jump a (Maybe SpecStore), [Point a])
-specJump = undefined --TODO: fix when adding PE support for processes
+specJump = undefined --TODO: fix when adding PE support for procedures
 -- specJump s decl Exit' =
 --   do let checkable = staticNonOutput decl s
 --      vs <- mapM (`find` s) checkable

--- a/src/PE/Specialization/Impl/Specialize.hs
+++ b/src/PE/Specialization/Impl/Specialize.hs
@@ -22,49 +22,52 @@ type Pending a = [(Point a, Point a)]
 type Seen a = Pending a
 
 specialize :: (Eq a, Show a) => VariableDecl -> Program' a -> SpecStore -> a -> LEM (Program a (Maybe SpecStore))
-specialize decl prog s entry =
-  do
-     b <- raise $ getEntry' prog
-     let pending = [((b,s), (entry, emptyMap))]
-     res <- specProg entry decl prog pending [] []
-     decl' <- raise $ specDecl decl prog -- specDecl decl
-     return (decl', reverse res) -- Reverse for nicer ordering of blocks
+specialize = undefined --TODO: fix when adding PE support for processes
+-- specialize decl prog s entry =
+--   do
+--      b <- raise $ getEntry' prog
+--      let pending = [((b,s), (entry, emptyMap))]
+--      res <- specProg entry decl prog pending [] []
+--      decl' <- raise $ specDecl decl prog -- specDecl decl
+--      return (decl', reverse res) -- Reverse for nicer ordering of blocks
 
 specDecl :: VariableDecl -> Program' a -> EM VariableDecl
-specDecl decl p =
-  do inBlock <- getEntryBlock' p
-     outBlock <- getExitBlock' p
-     let inDiv = initDiv inBlock
-     let outDiv = initDiv outBlock
-     let inp = filter (\n -> isType n BTDynamic inDiv) $ input decl
-     let out = filter (\n -> isType n BTDynamic outDiv) $ output decl
-     let potentialTemp = filter (\n -> n `notElem` (inp ++ out)) $ allVars decl
-     let tmp = filter (\n -> any (isDynInB n) p) potentialTemp
-     return VariableDecl { input = inp, output = out, temp = tmp }
-  where
-    isDynInB n b = isType n BTDynamic (initDiv b)
+specDecl = undefined --TODO: fix when adding PE support for processes
+-- specDecl decl p =
+--   do inBlock <- getEntryBlock' p
+--      outBlock <- getExitBlock' p
+--      let inDiv = initDiv inBlock
+--      let outDiv = initDiv outBlock
+--      let inp = filter (\n -> isType n BTDynamic inDiv) $ input decl
+--      let out = filter (\n -> isType n BTDynamic outDiv) $ output decl
+--      let potentialTemp = filter (\n -> n `notElem` (inp ++ out)) $ allVars decl
+--      let tmp = filter (\n -> any (isDynInB n) p) potentialTemp
+--      return VariableDecl { input = inp, output = out, temp = tmp }
+--   where
+--     isDynInB n b = isType n BTDynamic (initDiv b)
 
 specProg :: (Eq a, Show a) => a -> VariableDecl -> Program' a -> Pending a -> Seen a -> [Block a (Maybe SpecStore)]
                             -> LEM [Block a (Maybe SpecStore)]
-specProg _ _ _ [] _ res =
-  do logM "Specialization done."; return res
-specProg entry decl prog (p:ps) seen res
-  | p `elem` seen =
-    do logM $ "REPEAT POINT: " ++ prettyAnn show (fst p)
-       specProg entry decl prog ps seen res
-  | otherwise =
-    do logM $ prettyAnn show (fst p)
-       let (current@(l, s), origin) = p
-       b <- raise $ getBlockErr' prog l
-       case specBlock entry decl s b origin of
-        Left e -> logM ("ERROR: " ++ e ) >>
-                  logM ("IN POINT: " ++ prettyAnn show (fst p)) >>
-                    specProg entry decl prog ps seen res
-        Right (b', p') -> do
-          let pnew = map (\x -> (x, current)) p'
-          let seen' = p : seen
-          res' <- merge b' res
-          specProg entry decl prog (pnew ++ ps) seen' res'
+specProg = undefined --TODO: fix when adding PE support for processes
+-- specProg _ _ _ [] _ res =
+--   do logM "Specialization done."; return res
+-- specProg entry decl prog (p:ps) seen res
+--   | p `elem` seen =
+--     do logM $ "REPEAT POINT: " ++ prettyAnn show (fst p)
+--        specProg entry decl prog ps seen res
+--   | otherwise =
+--     do logM $ prettyAnn show (fst p)
+--        let (current@(l, s), origin) = p
+--        b <- raise $ getBlockErr' prog l
+--        case specBlock entry decl s b origin of
+--         Left e -> logM ("ERROR: " ++ e ) >>
+--                   logM ("IN POINT: " ++ prettyAnn show (fst p)) >>
+--                     specProg entry decl prog ps seen res
+--         Right (b', p') -> do
+--           let pnew = map (\x -> (x, current)) p'
+--           let seen' = p : seen
+--           res' <- merge b' res
+--           specProg entry decl prog (pnew ++ ps) seen' res'
 
 merge :: (Eq a, Show a) => Block a (Maybe SpecStore) -> [Block a (Maybe SpecStore)]
                             -> LEM [Block a (Maybe SpecStore)]

--- a/src/Parsing/Impl/Program.hs
+++ b/src/Parsing/Impl/Program.hs
@@ -16,10 +16,10 @@ parseProg = parseStr pProg
 
 -- parse a program
 pProg :: Parser (Program Label ())
-pProg = many1 pProcess
+pProg = many1 pProcedure
 
-pProcess :: Parser (Process Label ())
-pProcess = undefined
+pProcedure :: Parser (Procedure Label ())
+pProcedure = undefined
 -- parse a block
 pBlock :: Parser (Block Label ())
 pBlock = Block <$> (pLabelName <* symbol ":")

--- a/src/Parsing/Impl/Program.hs
+++ b/src/Parsing/Impl/Program.hs
@@ -16,15 +16,10 @@ parseProg = parseStr pProg
 
 -- parse a program
 pProg :: Parser (Program Label ())
-pProg = (,) <$> (whitespace *> pDecl) <*> many1 pBlock
+pProg = many1 pProcess
 
--- parse a variable declaration
-pDecl :: Parser VariableDecl
-pDecl =
-  VariableDecl <$> pNames <*> (symbol "->" *> pNames)
-               <*> option [] (word "with" *> pNames)
-  where pNames = symbol "(" *> many pName <* symbol ")"
-
+pProcess :: Parser (Process Label ())
+pProcess = undefined
 -- parse a block
 pBlock :: Parser (Block Label ())
 pBlock = Block <$> (pLabelName <* symbol ":")
@@ -35,16 +30,20 @@ pBlock = Block <$> (pLabelName <* symbol ":")
 -- parse a come-from
 pFrom :: Parser (ComeFrom Label ())
 pFrom = choice
-  [ Entry () <$ word "entry"
-  , Fi <$> (word "fi" *> pExpr) <*> (word "from" *> pLabelName) <*> (word "else" *> pLabelName)
+  [ 
+    -- TODO: fix
+    -- Entry () <$ word "entry"
+  Fi <$> (word "fi" *> pExpr) <*> (word "from" *> pLabelName) <*> (word "else" *> pLabelName)
   , From <$> (word "from" *> pLabelName)
   ] <?> "Expecting a from"
 
 -- parse a jump
 pJump :: Parser (Jump Label ())
 pJump = choice
-  [ Exit () <$ word "exit"
-  , If <$> (word "if" *> pExpr)  <*> (word "goto" *> pLabelName) <*> (word "else" *> pLabelName)
+  [ 
+    --TODO: fix
+    --Exit () <$ word "exit"
+  If <$> (word "if" *> pExpr)  <*> (word "goto" *> pLabelName) <*> (word "else" *> pLabelName)
   , Goto <$> (word "goto" *> pLabelName)
   ] <?> "Expecting a jump"
 

--- a/src/Parsing/Impl/Program.hs
+++ b/src/Parsing/Impl/Program.hs
@@ -19,7 +19,7 @@ pProg :: Parser (Program Label ())
 pProg = many1 pProcedure
 
 pProcedure :: Parser (Procedure Label ())
-pProcedure = undefined --TODO: fix when adding parsing for processes
+pProcedure = undefined --TODO: fix when adding parsing for procedures
 
 -- parse a block
 pBlock :: Parser (Block Label ())

--- a/src/RL/AST.hs
+++ b/src/RL/AST.hs
@@ -122,10 +122,10 @@ mapProgram f g = map changeBlock
       , jump = appJump $ jump b
       }
     appName (l, s) = (f l s, g s)
-    appFrom (Entry p s) = Entry p (g s)  --TODO: is correct?
+    appFrom (Entry p s) = Entry p (g s)
     appFrom (From (l, s)) = From (f l s, g s)
     appFrom (Fi e (l1, s1) (l2, s2)) = Fi e (f l1 s1, g s1) (f l2 s2, g s2)
-    appJump (Exit p s) = Exit p (g s) -- TODO: is correct?
+    appJump (Exit p s) = Exit p (g s)
     appJump (Goto (l, s)) = Goto (f l s, g s)
     appJump (If e (l1, s1) (l2, s2)) = If e (f l1 s1, g s1) (f l2 s2, g s2)
 
@@ -140,12 +140,12 @@ mapBlock f b = b
   }
 
 mapFrom :: ((a, b) -> (c, b)) -> ComeFrom a b -> ComeFrom c b
-mapFrom _ (Entry p s) = Entry p s --TODO: is correct?
+mapFrom _ (Entry p s) = Entry p s
 mapFrom f (From l) = From (f l)
 mapFrom f (Fi e l1 l2) = Fi e (f l1) (f l2)
 
 mapJump :: ((a, b) -> (c, b)) -> Jump a b -> Jump c b
-mapJump _ (Exit p s) = Exit p s --TODO: is correct?
+mapJump _ (Exit p s) = Exit p s
 mapJump f (Goto l) = Goto (f l)
 mapJump f (If e l1 l2) = If e (f l1) (f l2)
 

--- a/src/RL/AST.hs
+++ b/src/RL/AST.hs
@@ -2,13 +2,21 @@ module RL.AST where
 
 import RL.Values
 
-type Program label store = (VariableDecl, [Block label store])
+type Program label store = [Process label store]
 
+--TODO: remove when implementing support for PE with processes
 data VariableDecl = VariableDecl
   { input  :: [Name]
   , output :: [Name]
   , temp   :: [Name]
   } deriving (Eq, Show, Read)
+
+
+data Process label store = Process 
+  { pname :: ProcessName
+  , pbody :: [Block label store]
+  }
+  deriving (Eq, Show, Read)
 
 data Block label store = Block
   { name :: (label, store)
@@ -21,13 +29,13 @@ data Block label store = Block
 data ComeFrom label store =
     From (label, store)
   | Fi Expr (label, store) (label, store)
-  | Entry store
+  | Entry Pattern store
   deriving (Eq, Show, Read)
 
 data Jump label store =
     Goto (label, store)
   | If Expr (label, store) (label, store)
-  | Exit store
+  | Exit Pattern store
   deriving (Eq, Show, Read)
 
 data Step =
@@ -48,6 +56,8 @@ data Pattern =
     QConst Value
   | QVar Name
   | QPair Pattern Pattern
+  | QCall ProcessName Pattern
+  | QUncall ProcessName Pattern
   deriving (Eq, Show, Read)
 
 data BinOp =
@@ -74,7 +84,13 @@ data UnOp =
   | Not
   deriving (Eq, Show, Read)
 
-type NormProgram label = (VariableDecl, [NormBlock label])
+type NormProgram label = [NormProcess label]
+data NormProcess label = NormProcess 
+  { npname :: ProcessName
+  , npbody :: [NormBlock label]
+  }
+  deriving (Eq, Show, Read)
+
 data NormBlock label = NormBlock
   { nname :: label
   , nfrom :: ComeFrom label ()
@@ -106,10 +122,10 @@ mapProgram f g = map changeBlock
       , jump = appJump $ jump b
       }
     appName (l, s) = (f l s, g s)
-    appFrom (Entry s) = Entry (g s)
+    appFrom (Entry p s) = Entry p (g s)
     appFrom (From (l, s)) = From (f l s, g s)
     appFrom (Fi e (l1, s1) (l2, s2)) = Fi e (f l1 s1, g s1) (f l2 s2, g s2)
-    appJump (Exit s) = Exit (g s)
+    appJump (Exit p s) = Exit p (g s)
     appJump (Goto (l, s)) = Goto (f l s, g s)
     appJump (If e (l1, s1) (l2, s2)) = If e (f l1 s1, g s1) (f l2 s2, g s2)
 
@@ -124,12 +140,12 @@ mapBlock f b = b
   }
 
 mapFrom :: ((a, b) -> (c, b)) -> ComeFrom a b -> ComeFrom c b
-mapFrom _ (Entry s) = Entry s
+mapFrom _ (Entry p s) = Entry p s
 mapFrom f (From l) = From (f l)
 mapFrom f (Fi e l1 l2) = Fi e (f l1) (f l2)
 
 mapJump :: ((a, b) -> (c, b)) -> Jump a b -> Jump c b
-mapJump _ (Exit s) = Exit s
+mapJump _ (Exit p s) = Exit p s
 mapJump f (Goto l) = Goto (f l)
 mapJump f (If e l1 l2) = If e (f l1) (f l2)
 
@@ -146,17 +162,17 @@ isNExit :: NormBlock a -> Bool
 isNExit = isJumpExit . njump
 
 isFromEntry :: ComeFrom a b -> Bool
-isFromEntry j = case j of Entry _ -> True; _ -> False
+isFromEntry j = case j of Entry _ _ -> True; _ -> False
 
 isJumpExit :: Jump a b -> Bool
-isJumpExit j = case j of Exit _ -> True; _ -> False
+isJumpExit j = case j of Exit _ _-> True; _ -> False
 
 fromLabels :: ComeFrom a b -> [(a, b)]
-fromLabels (Entry _) = []
+fromLabels (Entry _ _) = []
 fromLabels (From l) = [l]
 fromLabels (Fi _ l1 l2) = [l1, l2]
 
 jumpLabels :: Jump a b -> [(a, b)]
-jumpLabels (Exit _) = []
+jumpLabels (Exit _ _) = []
 jumpLabels (Goto l) = [l]
 jumpLabels (If _ l1 l2) = [l1, l2]

--- a/src/RL/AST.hs
+++ b/src/RL/AST.hs
@@ -2,9 +2,9 @@ module RL.AST where
 
 import RL.Values
 
-type Program label store = [Process label store]
+type Program label store = [Procedure label store]
 
---TODO: remove when implementing support for PE with processes
+--TODO: remove when implementing support for PE with procedures
 data VariableDecl = VariableDecl
   { input  :: [Name]
   , output :: [Name]
@@ -12,8 +12,8 @@ data VariableDecl = VariableDecl
   } deriving (Eq, Show, Read)
 
 
-data Process label store = Process 
-  { pname :: ProcessName
+data Procedure label store = Procedure 
+  { pname :: ProcedureName
   , pbody :: [Block label store]
   }
   deriving (Eq, Show, Read)
@@ -56,8 +56,8 @@ data Pattern =
     QConst Value
   | QVar Name
   | QPair Pattern Pattern
-  | QCall ProcessName Pattern
-  | QUncall ProcessName Pattern
+  | QCall ProcedureName Pattern
+  | QUncall ProcedureName Pattern
   deriving (Eq, Show, Read)
 
 data BinOp =
@@ -84,9 +84,9 @@ data UnOp =
   | Not
   deriving (Eq, Show, Read)
 
-type NormProgram label = [NormProcess label]
-data NormProcess label = NormProcess 
-  { npname :: ProcessName
+type NormProgram label = [NormProcedure label]
+data NormProcedure label = NormProcedure 
+  { npname :: ProcedureName
   , npbody :: [NormBlock label]
   }
   deriving (Eq, Show, Read)

--- a/src/RL/Impl/Wellformed.hs
+++ b/src/RL/Impl/Wellformed.hs
@@ -10,26 +10,15 @@ import RL.Variables
 import qualified Data.Set as S
 
 wellformedProg :: (Eq a, Show a, Eq b, Show b) => Program a b -> EM ()
-wellformedProg (decl, p) =
-  do _ <- wellformedDecl decl
-     _ <- getEntryBlock p
-     _ <- getExitBlock p
-     let vars = allVars decl
-     mapM_ (wellformedBlock p vars) p
+wellformedProg p =
+  do
+    entryProcess <- getEntryProcess p
+    _ <- getEntryBlock (pbody entryProcess)
+    _ <- getExitBlock (pbody entryProcess)
+    mapM_ (welformedProcesses p) p
 
-wellformedDecl :: VariableDecl -> EM ()
-wellformedDecl decl =
-  let intraVar = not (repeatedVars inp || repeatedVars out || repeatedVars tmp)
-      interVar = notTemp inp && notTemp out
-  in if intraVar && interVar
-    then return ()
-    else Left "Malformed declaration"
-  where
-    inp = input decl
-    out = output decl
-    tmp = temp decl
-    repeatedVars vs = length vs /= S.size (S.fromList vs)
-    notTemp = all (`notElem` tmp)
+welformedProcesses :: (Eq a, Show a, Eq b, Show b) => [Process a b] -> Process a b -> EM ()
+welformedProcesses = undefined -- TODO: implement
 
 wellformedBlock :: (Eq a, Show a, Eq b, Show b) => [Block a b] -> [Name] -> Block a b -> EM ()
 wellformedBlock p ns b =
@@ -55,13 +44,13 @@ wellformedJump :: [Name] -> Jump a b -> EM ()
 wellformedJump _ (Goto _) = return ()
 wellformedJump ns (If e _ _) =
   wellformedExp ns e
-wellformedJump _ (Exit _) = return ()
+wellformedJump ns (Exit p _) = wellformedPat ns p
 
 wellformedFrom :: [Name] -> ComeFrom a b -> EM ()
 wellformedFrom _  (From _) = return ()
 wellformedFrom ns (Fi e _ _) =
   wellformedExp ns e
-wellformedFrom _  (Entry _) = return ()
+wellformedFrom ns  (Entry p _) = wellformedPat ns p
 
 wellformedStep :: [Name] -> Step -> EM ()
 wellformedStep _ Skip = return ()

--- a/src/RL/Impl/Wellformed.hs
+++ b/src/RL/Impl/Wellformed.hs
@@ -8,17 +8,18 @@ import RL.Values
 import RL.Variables
 
 import qualified Data.Set as S
+import RL.AST (Procedure)
 
 wellformedProg :: (Eq a, Show a, Eq b, Show b) => Program a b -> EM ()
 wellformedProg p =
   do
-    entryProcess <- getEntryProcess p
-    _ <- getEntryBlock (pbody entryProcess)
-    _ <- getExitBlock (pbody entryProcess)
-    mapM_ (welformedProcesses p) p
+    entryProcedure <- getEntryProcedure p
+    _ <- getEntryBlock (pbody entryProcedure)
+    _ <- getExitBlock (pbody entryProcedure)
+    mapM_ (welformedProcedures p) p
 
-welformedProcesses :: (Eq a, Show a, Eq b, Show b) => [Process a b] -> Process a b -> EM ()
-welformedProcesses = undefined -- TODO: implement
+welformedProcedures :: (Eq a, Show a, Eq b, Show b) => [Procedure a b] -> Procedure a b -> EM ()
+welformedProcedures = undefined -- TODO: implement
 
 wellformedBlock :: (Eq a, Show a, Eq b, Show b) => [Block a b] -> [Name] -> Block a b -> EM ()
 wellformedBlock p ns b =

--- a/src/RL/Program.hs
+++ b/src/RL/Program.hs
@@ -65,8 +65,8 @@ getExitName = name . head . filter isExit
 getExitLabel :: [Block a b] -> a
 getExitLabel = label . head . filter isExit
 
-getEntryProcess :: [Process a b] -> EM (Process a b)
-getEntryProcess p =
+getEntryProcedure :: [Procedure a b] -> EM (Procedure a b)
+getEntryProcedure p =
   case p of
-    [] -> Left "No processes found"
+    [] -> Left "No procedures found"
     (h:rs) -> Right h

--- a/src/RL/Program.hs
+++ b/src/RL/Program.hs
@@ -64,3 +64,9 @@ getExitName = name . head . filter isExit
 
 getExitLabel :: [Block a b] -> a
 getExitLabel = label . head . filter isExit
+
+getEntryProcess :: [Process a b] -> EM (Process a b)
+getEntryProcess p =
+  case p of
+    [] -> Left "No processes found"
+    (h:rs) -> Right h

--- a/src/RL/Values.hs
+++ b/src/RL/Values.hs
@@ -5,7 +5,7 @@ import qualified Data.Map.Strict as Map
 type IntType = Word
 type Name = String
 type Label = String
-type ProcessName = String
+type ProcedureName = String
 data Value =
     Atom String
   | Num  IntType

--- a/src/RL/Values.hs
+++ b/src/RL/Values.hs
@@ -5,7 +5,7 @@ import qualified Data.Map.Strict as Map
 type IntType = Word
 type Name = String
 type Label = String
-
+type ProcessName = String
 data Value =
     Atom String
   | Num  IntType

--- a/src/RL/Variables.hs
+++ b/src/RL/Variables.hs
@@ -4,7 +4,7 @@ import RL.AST
 import RL.Values
 
 import Data.List (union)
-
+-- TODO: fix these
 nonInput :: VariableDecl -> [Name]
 nonInput decl = filter (`notElem` input decl) $ allVars decl
 

--- a/src/Utils/PrettyPrint.hs
+++ b/src/Utils/PrettyPrint.hs
@@ -49,7 +49,10 @@ prettyStore :: Store -> String
 prettyStore = concatMap (\(n, v) -> n ++ "=" ++ prettyVal v ++ " ") . toList
 
 prettyProg :: Print a -> Program a () -> String
-prettyProg f (decl, p)= prettyDecl decl ++ intercalate "\n" (concatMap (prettyBlock f) p)
+prettyProg f  p= intercalate "\n" (concatMap (prettyProcess f) p)
+
+prettyProcess :: Print a -> Process a () -> [String]
+prettyProcess = undefined -- TODO
 
 prettyDecl :: VariableDecl -> String
 prettyDecl d =
@@ -70,7 +73,7 @@ prettyFrom f (Fi e (l1, ()) (l2, ())) =
   [ "fi " ++ prettyExpr e
   , "\tfrom " ++ f l1
   , "\telse " ++ f l2]
-prettyFrom _ (Entry ()) = ["entry"]
+prettyFrom _ (Entry p ()) = ["entry( " ++ prettyPat p ++ ")"]
 
 prettyJump :: Print a -> Jump a () -> [String]
 prettyJump f (Goto (l, ()))= ["goto " ++ f l]
@@ -78,7 +81,7 @@ prettyJump f (If e (l1, ()) (l2, ())) =
   [ "if " ++ prettyExpr e
   , "\tgoto " ++ f l1
   , "\telse " ++ f l2]
-prettyJump _ (Exit ()) = ["exit"]
+prettyJump _ (Exit p ()) = ["exit( " ++ prettyPat p ++ " )"]
 
 prettyStep :: Step -> String
 prettyStep (Update n rop e) = n ++ " " ++ prettyROp rop ++ "= " ++ prettyExpr e

--- a/src/Utils/PrettyPrint.hs
+++ b/src/Utils/PrettyPrint.hs
@@ -136,7 +136,10 @@ prettyVal (Pair v1 v2) = "("++ prettyVal v1 ++ "." ++ prettyVal v2 ++ ")"
 prettyVal Nil = "nil"
 
 prettyProg' :: Print a -> Program' a -> String
-prettyProg' f p = intercalate "\n" (concatMap (prettyBlock' f) p)
+prettyProg' f p = intercalate "\n" (concatMap (prettyProcess' f) p)
+
+prettyProcess' :: Print a -> Process' a -> [String]
+prettyProcess' = undefined --TODO: fix when adding PE support for processes
 
 prettyBlock' :: Print a -> Block' a -> [String]
 prettyBlock' f b =

--- a/src/Utils/PrettyPrint.hs
+++ b/src/Utils/PrettyPrint.hs
@@ -49,10 +49,10 @@ prettyStore :: Store -> String
 prettyStore = concatMap (\(n, v) -> n ++ "=" ++ prettyVal v ++ " ") . toList
 
 prettyProg :: Print a -> Program a () -> String
-prettyProg f  p= intercalate "\n" (concatMap (prettyProcess f) p)
+prettyProg f  p= intercalate "\n" (concatMap (prettyProcedure f) p)
 
-prettyProcess :: Print a -> Process a () -> [String]
-prettyProcess = undefined -- TODO
+prettyProcedure :: Print a -> Procedure a () -> [String]
+prettyProcedure = undefined -- TODO
 
 prettyDecl :: VariableDecl -> String
 prettyDecl d =
@@ -136,10 +136,10 @@ prettyVal (Pair v1 v2) = "("++ prettyVal v1 ++ "." ++ prettyVal v2 ++ ")"
 prettyVal Nil = "nil"
 
 prettyProg' :: Print a -> Program' a -> String
-prettyProg' f p = intercalate "\n" (concatMap (prettyProcess' f) p)
+prettyProg' f p = intercalate "\n" (concatMap (prettyProcedure' f) p)
 
-prettyProcess' :: Print a -> Process' a -> [String]
-prettyProcess' = undefined --TODO: fix when adding PE support for processes
+prettyProcedure' :: Print a -> Procedure' a -> [String]
+prettyProcedure' = undefined --TODO: fix when adding PE support for procedures
 
 prettyBlock' :: Print a -> Block' a -> [String]
 prettyBlock' f b =

--- a/src/Utils/PrettyPrint.hs
+++ b/src/Utils/PrettyPrint.hs
@@ -73,7 +73,7 @@ prettyFrom f (Fi e (l1, ()) (l2, ())) =
   [ "fi " ++ prettyExpr e
   , "\tfrom " ++ f l1
   , "\telse " ++ f l2]
-prettyFrom _ (Entry p ()) = ["entry( " ++ prettyPat p ++ ")"]
+prettyFrom _ (Entry p ()) = ["entry " ++ prettyPat p]
 
 prettyJump :: Print a -> Jump a () -> [String]
 prettyJump f (Goto (l, ()))= ["goto " ++ f l]
@@ -81,7 +81,7 @@ prettyJump f (If e (l1, ()) (l2, ())) =
   [ "if " ++ prettyExpr e
   , "\tgoto " ++ f l1
   , "\telse " ++ f l2]
-prettyJump _ (Exit p ()) = ["exit( " ++ prettyPat p ++ " )"]
+prettyJump _ (Exit p ()) = ["exit " ++ prettyPat p]
 
 prettyStep :: Step -> String
 prettyStep (Update n rop e) = n ++ " " ++ prettyROp rop ++ "= " ++ prettyExpr e


### PR DESCRIPTION
Extended AST with new grammar supporting procedures.

Then moved on to "fixing" all the errors that occurred as a result of this change.
This was done by either
 - Fixing error, in cases where the fix was trivial
 - Commenting out function/case and substituting with undefined in non-trivial cases.

Following PRs should be alot smaller, since now it is possible to start implementing the extended version of ARL incrementally.
e.g. implementing the parser can be done without having to touch the interpreter or PE modules.
 
 